### PR TITLE
DM-15901: Access metadata exclusively through Butler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *~
 .cache
 .coverage
+.pytest_cache
 pytest_session.txt
 .sconf_temp
 .sconsign.dblite

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -37,9 +37,7 @@ from .dataset import Dataset
 from .ingestion import ingestDataset
 from .metrics import MetricsParser, checkSquashReady, AutoJob
 from .pipeline_driver import ApPipeParser, runApPipe, _getConfig
-from .measurements import measureFromMetadata, \
-    measureFromButlerRepo, \
-    measureFromPpdb
+from .measurements import measureFromButlerRepo, measureFromPpdb
 from .workspace import Workspace
 
 
@@ -132,7 +130,7 @@ class _DatasetAction(argparse.Action):
         setattr(namespace, self.dest, Dataset(values))
 
 
-def _measureFinalProperties(metricsJob, metadata, workspace, args):
+def _measureFinalProperties(metricsJob, workspace, args):
     """Measure any metrics that apply to the final result of the AP pipeline,
     rather than to a particular processing stage.
 
@@ -140,8 +138,6 @@ def _measureFinalProperties(metricsJob, metadata, workspace, args):
     ----------
     metricsJob : `lsst.verify.Job`
         The Job object to which to add any metric measurements made.
-    metadata : `lsst.daf.base.PropertySet`
-        The metadata produced by the AP pipeline.
     workspace : `lsst.ap.verify.workspace.Workspace`
         The abstract location containing input and output repositories.
     args : `argparse.Namespace`
@@ -149,7 +145,6 @@ def _measureFinalProperties(metricsJob, metadata, workspace, args):
         supported by `lsst.ap.verify.pipeline_driver.ApPipeParser`.
     """
     measurements = []
-    measurements.extend(measureFromMetadata(metadata))
     measurements.extend(measureFromButlerRepo(workspace.outputRepo, args.dataId))
     # TODO: Add butler storage and retrieval of the Ppdb config. DM-16645
     measurements.extend(measureFromPpdb(_getConfig(workspace).ppdb))
@@ -183,8 +178,8 @@ def runApVerify(cmdLine=None):
 
     with AutoJob(args) as job:
         log.info('Running pipeline...')
-        metadata = runApPipe(job, workspace, args)
-        _measureFinalProperties(job, metadata, workspace, args)
+        runApPipe(job, workspace, args)
+        _measureFinalProperties(job, workspace, args)
 
 
 def runIngestion(cmdLine=None):

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -447,11 +447,6 @@ def ingestDataset(dataset, workspace):
         If the repositories already exist, they must be compatible with
         ``dataset`` (in particular, they must support the relevant
         ``obs`` package).
-
-    Returns
-    -------
-    metadata : `lsst.daf.base.PropertySet`
-        The full metadata from any Tasks called by this function.
     """
     # TODO: generalize to support arbitrary URIs (DM-11482)
     log = lsst.log.Log.getLogger("ap.verify.ingestion.ingestDataset")
@@ -459,7 +454,6 @@ def ingestDataset(dataset, workspace):
     ingester = DatasetIngestTask(config=_getConfig(dataset))
     ingester.run(dataset, workspace)
     log.info("Data ingested")
-    return ingester.getFullMetadata()
 
 
 def _getConfig(dataset):

--- a/python/lsst/ap/verify/measurements/compute_metrics.py
+++ b/python/lsst/ap/verify/measurements/compute_metrics.py
@@ -27,12 +27,12 @@ The rest of `ap_verify` should access `measurements` through the functions
 defined here, rather than depending on individual measurement functions.
 """
 
-__all__ = ["measureFromMetadata",
-           "measureFromButlerRepo",
+__all__ = ["measureFromButlerRepo",
            "measureFromPpdb"]
 
 import re
 
+from lsst.ap.pipe import ApPipeTask
 from lsst.ap.verify.config import Config
 import lsst.daf.persistence as dafPersist
 import lsst.dax.ppdb as daxPpdb
@@ -120,6 +120,9 @@ def measureFromButlerRepo(repo, dataId):
         butler, dataIdDict, "ip_diffim.fracDiaSourcesToSciSources")
     if measurement is not None:
         result.append(measurement)
+
+    metadata = butler.get(ApPipeTask._DefaultName + '_metadata', dataId=dataIdDict)
+    result.extend(measureFromMetadata(metadata))
     return result
 
 

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -185,11 +185,6 @@ def runApPipe(metricsJob, workspace, parsedCmdLine):
     parsedCmdLine : `argparse.Namespace`
         Command-line arguments, including all arguments supported by `ApPipeParser`.
 
-    Returns
-    -------
-    metadata : `lsst.daf.base.PropertySet`
-        The metadata from any tasks called by the pipeline. May be empty.
-
     Raises
     ------
     lsst.ap.verify.pipeline_driver.MeasurementStorageError
@@ -216,7 +211,6 @@ def runApPipe(metricsJob, workspace, parsedCmdLine):
         for dataRef in dafPersist.searchDataRefs(workspace.workButler, datasetType='calexp', dataId=dataId):
             pipeline.writeMetadata(dataRef)
         log.info('Pipeline complete')
-        return pipeline.getFullMetadata()
     finally:
         # Recover any metrics from completed pipeline steps, even if the pipeline fails
         _updateMetrics(pipeline.getFullMetadata(), metricsJob)

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -103,76 +103,6 @@ def _updateMetrics(metadata, job):
         raise MeasurementStorageError('Task metadata could not be read; possible downstream bug') from e
 
 
-def _process(pipeline, workspace, dataId, parallelization):
-    """Run single-frame processing on a dataset.
-
-    Parameters
-    ----------
-    pipeline : `lsst.ap.pipe.ApPipeTask`
-        An instance of the AP pipeline.
-    workspace : `lsst.ap.verify.workspace.Workspace`
-        The abstract location containing input and output repositories.
-    dataId : `dict` from `str` to any
-        Butler identifier naming the data to be processed by the underlying
-        task(s).
-    parallelization : `int`
-        Parallelization level at which to run underlying task(s).
-    """
-    for dataRef in dafPersist.searchDataRefs(workspace.workButler, datasetType='raw', dataId=dataId):
-        pipeline.runProcessCcd(dataRef)
-
-
-def _difference(pipeline, workspace, dataId, parallelization):
-    """Run image differencing on a dataset.
-
-    Parameters
-    ----------
-    pipeline : `lsst.ap.pipe.ApPipeTask`
-        An instance of the AP pipeline.
-    workspace : `lsst.ap.verify.workspace.Workspace`
-        The abstract location containing input and output repositories.
-    dataId : `dict` from `str` to any
-        Butler identifier naming the data to be processed by the underlying
-        task(s).
-    parallelization : `int`
-        Parallelization level at which to run underlying task(s).
-    """
-    for dataRef in dafPersist.searchDataRefs(workspace.workButler, datasetType='calexp', dataId=dataId):
-        pipeline.runDiffIm(dataRef)
-
-
-def _associate(pipeline, workspace, dataId, parallelization):
-    """Run source association on a dataset.
-
-    Parameters
-    ----------
-    pipeline : `lsst.ap.pipe.ApPipeTask`
-        An instance of the AP pipeline.
-    workspace : `lsst.ap.verify.workspace.Workspace`
-        The abstract location containing output repositories.
-    dataId : `dict` from `str` to any
-        Butler identifier naming the data to be processed by the underlying
-        task(s).
-    parallelization : `int`
-        Parallelization level at which to run underlying task(s).
-    """
-    for dataRef in dafPersist.searchDataRefs(workspace.workButler, datasetType='calexp', dataId=dataId):
-        pipeline.runAssociation(dataRef)
-
-
-def _postProcess(workspace):
-    """Run post-processing on a dataset.
-
-    This step is called the "afterburner" in some design documents.
-
-    Parameters
-    ----------
-    workspace : `lsst.ap.verify.workspace.Workspace`
-        The abstract location containing output repositories.
-    """
-    pass
-
-
 def runApPipe(metricsJob, workspace, parsedCmdLine):
     """Run `ap_pipe` on this object's dataset.
 
@@ -195,20 +125,12 @@ def runApPipe(metricsJob, workspace, parsedCmdLine):
     log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipe')
 
     dataId = _parseDataId(parsedCmdLine.dataId)
-    processes = parsedCmdLine.processes
 
     pipeline = apPipe.ApPipeTask(workspace.workButler, config=_getConfig(workspace))
     try:
-        _process(pipeline, workspace, dataId, processes)
-        log.info('Single-frame processing complete')
-
-        _difference(pipeline, workspace, dataId, processes)
-        log.info('Image differencing complete')
-        _associate(pipeline, workspace, dataId, processes)
-        log.info('Source association complete')
-
-        _postProcess(workspace)
-        for dataRef in dafPersist.searchDataRefs(workspace.workButler, datasetType='calexp', dataId=dataId):
+        for dataRef in dafPersist.searchDataRefs(workspace.workButler, datasetType='raw',
+                                                 dataId=dataId):
+            pipeline.runDataRef(dataRef)
             pipeline.writeMetadata(dataRef)
         log.info('Pipeline complete')
     finally:

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -213,6 +213,8 @@ def runApPipe(metricsJob, workspace, parsedCmdLine):
         log.info('Source association complete')
 
         _postProcess(workspace)
+        for dataRef in dafPersist.searchDataRefs(workspace.workButler, datasetType='calexp', dataId=dataId):
+            pipeline.writeMetadata(dataRef)
         log.info('Pipeline complete')
         return pipeline.getFullMetadata()
     finally:

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -121,19 +121,6 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
     # Mock up ApPipeTask to avoid doing any processing.
     @unittest.mock.patch("lsst.ap.verify.pipeline_driver._getConfig", return_value=None)
     @patchApPipe
-    def testRunApPipeReturn(self, _mockConfig, mockClass):
-        """Test that runApPipe runs the pipeline and returns the Task object's(s') metadata.
-        """
-        mockClass.return_value.getFullMetadata.return_value = PipelineDriverTestSuite.dummyMetadata()
-
-        metadata = pipeline_driver.runApPipe(self.job, self.workspace, self.apPipeArgs)
-
-        self.assertEqual(len(metadata.paramNames(topLevelOnly=False)), 1)
-        self.assertEqual(metadata.getScalar("lsst.ap.pipe.ccdProcessor.cycleCount"), 42)
-
-    # Mock up ApPipeTask to avoid doing any processing.
-    @unittest.mock.patch("lsst.ap.verify.pipeline_driver._getConfig", return_value=None)
-    @patchApPipe
     def testRunApPipeSteps(self, _mockConfig, mockClass):
         """Test that runApPipe runs the entire pipeline.
         """

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -124,13 +124,9 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
     def testRunApPipeSteps(self, _mockConfig, mockClass):
         """Test that runApPipe runs the entire pipeline.
         """
-        # This test case is sensitive to the implementation of pipeline_driver
-        # Specifically, it needs to know that ApPipeTask.run is not called
         pipeline_driver.runApPipe(self.job, self.workspace, self.apPipeArgs)
 
-        mockClass.return_value.runProcessCcd.assert_called_once()
-        mockClass.return_value.runDiffIm.assert_called_once()
-        mockClass.return_value.runAssociation.assert_called_once()
+        mockClass.return_value.runDataRef.assert_called_once()
 
     def testUpdateMetricsEmpty(self):
         """Test that _updateMetrics does not add metrics if no job files are provided.
@@ -167,7 +163,7 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
         metadata.add("lsst.ap.pipe.ccdProcessor.verify_json_path", subtaskFile)
 
         mockClass.return_value.getFullMetadata.return_value = metadata
-        mockClass.return_value.runDiffIm.side_effect = RuntimeError("DECam is weird!")
+        mockClass.return_value.runDataRef.side_effect = RuntimeError("DECam is weird!")
 
         self.assertNotEqual(self.job.measurements, self.subtaskJob.measurements)
 


### PR DESCRIPTION
This PR treats metadata-based metrics as a special case of Butler-based metrics, removing `measureFromMetadata` from the `measurements` package's API. It also removes a lot of the vestigial infrastructure that was originally created to juggle metadata, greatly simplifying `pipeline_driver`.

`pipeline_driver` still uses metadata as a workaround for the lack of Butler support in `lsst.verify.Job`; it may be possible to remove this at a later date.