### PR TITLE
DM-16319: ap_verify source count metrics do not exist

### DIFF
--- a/python/lsst/ap/verify/measurements/association.py
+++ b/python/lsst/ap/verify/measurements/association.py
@@ -50,7 +50,7 @@ def measureNumberNewDiaObjects(metadata, taskName, metricName):
         contexts, the information for only one run will be provided.
     metricName : `str`
         The fully qualified name of the metric being measured, e.g.,
-        "association.numNewDiaObjects"
+        "ap_association.numNewDiaObjects"
 
     Returns
     -------
@@ -82,7 +82,7 @@ def measureNumberUnassociatedDiaObjects(metadata, taskName, metricName):
         contexts, the information for only one run will be provided.
     metricName : `str`
         The fully qualified name of the metric being measured, e.g.,
-        "association.numUnassociatedDiaObjects"
+        "ap_association.numUnassociatedDiaObjects"
 
     Returns
     -------
@@ -114,7 +114,7 @@ def measureFractionUpdatedDiaObjects(metadata, taskName, metricName):
         contexts, the information for only one run will be provided.
     metricName : `str`
         The fully qualified name of the metric being measured, e.g.,
-        "association.fracUpdatedDiaObjects"
+        "ap_association.fracUpdatedDiaObjects"
 
     Returns
     -------
@@ -209,7 +209,7 @@ def measureTotalUnassociatedDiaObjects(dbCursor, metricName):
         AssociationDBSqlite task to load.
     metricName : `str`
         The fully qualified name of the metric being measured, e.g.,
-        "association.totalUnassociatedDiaObjects"
+        "ap_association.totalUnassociatedDiaObjects"
 
     Returns
     -------

--- a/python/lsst/ap/verify/measurements/compute_metrics.py
+++ b/python/lsst/ap/verify/measurements/compute_metrics.py
@@ -76,15 +76,15 @@ def measureFromMetadata(metadata):
             result.append(measurement)
 
     measurement = measureNumberNewDiaObjects(
-        metadata, 'apPipe:associator', 'association.numNewDiaObjects')
+        metadata, 'apPipe:associator', 'ap_association.numNewDiaObjects')
     if measurement is not None:
         result.append(measurement)
     measurement = measureFractionUpdatedDiaObjects(
-        metadata, 'apPipe:associator', 'association.fracUpdatedDiaObjects')
+        metadata, 'apPipe:associator', 'ap_association.fracUpdatedDiaObjects')
     if measurement is not None:
         result.append(measurement)
     measurement = measureNumberUnassociatedDiaObjects(
-        metadata, 'apPipe:associator', 'association.numUnassociatedDiaObjects')
+        metadata, 'apPipe:associator', 'ap_association.numUnassociatedDiaObjects')
     if measurement is not None:
         result.append(measurement)
     return result
@@ -172,7 +172,7 @@ def measureFromL1DbSqlite(dbName):
 
     result = []
     measurement = measureTotalUnassociatedDiaObjects(
-        dbCursor, "association.totalUnassociatedDiaObjects")
+        dbCursor, "ap_association.totalUnassociatedDiaObjects")
     if measurement is not None:
         result.append(measurement)
 


### PR DESCRIPTION
This PR changes the namespace of `ap_association` metrics from `association` to `ap_association`. This change is needed to correctly interoperate with the metrics as registered in lsst/verify_metrics#14.