### PR TITLE
DM-16400: Create a timing metric for ApPipeTask

### DIFF
--- a/config/dataset_config.yaml
+++ b/config/dataset_config.yaml
@@ -4,6 +4,7 @@ datasets:
     CI-HiTS2015: ap_verify_ci_hits2015
 measurements:
     timing:
+        apPipe: ap_pipe.ApPipeTime
         apPipe:ccdProcessor: pipe_tasks.ProcessCcdTime
         apPipe:ccdProcessor:isr: ip_isr.IsrTime
         apPipe:ccdProcessor:charImage: pipe_tasks.CharacterizeImageTime


### PR DESCRIPTION
This PR adds a metric for extracting timing information from `ApPipeTask`. Note that the metric will not be measurable until some changes to `pipeline_driver` are merged in #49.