### PR TITLE
DM-16333: Add Job metadata to the ap job.

### DIFF
--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -144,7 +144,6 @@ def runApPipe(metricsJob, workspace, parsedCmdLine):
     #  Insert job metadata including dataId
     metricsJob.meta.update({'instrument': _extract_instrument_from_butler(workspace.workButler)})
     metricsJob.meta.update(dataId)
-    #  I think we could probably send in the test repo directory too, but I don't know how to get that here.
 
     pipeline = apPipe.ApPipeTask(workspace.workButler, config=_getConfig(workspace))
     try:

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -43,6 +43,19 @@ import lsst.ap.pipe as apPipe
 from lsst.verify import Job
 
 
+# borrowed from validate_drp
+def _extract_instrument_from_butler(butler):
+    """Extract the last part of the mapper name from a Butler repo.
+    'lsst.obs.lsstSim.lsstSimMapper.LsstSimMapper' -> 'LSSTSIM'
+    'lsst.obs.cfht.megacamMapper.MegacamMapper' -> 'CFHT'
+    'lsst.obs.decam.decamMapper.DecamMapper' -> 'DECAM'
+    'lsst.obs.hsc.hscMapper.HscMapper' -> 'HSC'
+    """
+    camera = butler.get('camera')
+    instrument = camera.getName()
+    return instrument.upper()
+
+
 class ApPipeParser(argparse.ArgumentParser):
     """An argument parser for data needed by ``ap_pipe`` activities.
 
@@ -125,6 +138,13 @@ def runApPipe(metricsJob, workspace, parsedCmdLine):
     log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipe')
 
     dataId = _parseDataId(parsedCmdLine.dataId)
+    #  After processes are implemented, remove the flake exception
+    processes = parsedCmdLine.processes  # noqa: F841
+
+    #  Insert job metadata including dataId
+    metricsJob.meta.update({'instrument': _extract_instrument_from_butler(workspace.workButler)})
+    metricsJob.meta.update(dataId)
+    #  I think we could probably send in the test repo directory too, but I don't know how to get that here.
 
     pipeline = apPipe.ApPipeTask(workspace.workButler, config=_getConfig(workspace))
     try:

--- a/ups/ap_verify.table
+++ b/ups/ap_verify.table
@@ -7,6 +7,7 @@ setupRequired(ip_isr)
 setupRequired(pipe_tasks)
 setupRequired(verify)
 setupRequired(ap_pipe)
+setupRequired(ap_association)
 
 setupOptional(ap_verify_testdata)
 setupOptional(obs_test)


### PR DESCRIPTION
@kfindeisen and @jhoblitt I think we could do something like this to get the appropriate metadata in the job.  Does this look reasonable, and how should I test?