### PR TITLE
DM-16017: Prototype a metrics-handling Task

### DIFF
--- a/python/lsst/ap/verify/measurements/__init__.py
+++ b/python/lsst/ap/verify/measurements/__init__.py
@@ -1,1 +1,2 @@
 from .compute_metrics import *
+from .profiling import TimingMetricConfig, TimingMetricTask

--- a/python/lsst/ap/verify/measurements/profiling.py
+++ b/python/lsst/ap/verify/measurements/profiling.py
@@ -26,11 +26,14 @@
 All measurements assume the necessary information is present in a task's metadata.
 """
 
-__all__ = ["measureRuntime"]
+__all__ = ["measureRuntime", "TimingMetricConfig", "TimingMetricTask"]
 
 import astropy.units as u
 
-import lsst.verify
+import lsst.pex.config as pexConfig
+from lsst.pipe.base import Struct
+from lsst.verify import Measurement, Name, MetricComputationError
+from lsst.verify.compatibility import MetricTask
 
 
 def measureRuntime(metadata, taskName, metricName):
@@ -67,8 +70,164 @@ def measureRuntime(metadata, taskName, metricName):
                         for key in keys if key.endswith(endKey)]
         if timedMethods:
             start, end = (metadata.getAsDouble(key) for key in timedMethods[0])
-            meas = lsst.verify.Measurement(metricName, (end - start) * u.second)
+            meas = Measurement(metricName, (end - start) * u.second)
             meas.notes['estimator'] = 'pipe.base.timeMethod'
             return meas
 
     return None
+
+
+class TimingMetricConfig(MetricTask.ConfigClass):
+    """Information that distinguishes one timing metric from another.
+    """
+    # It would be more user-friendly to identify the top-level task and call
+    # CmdLineTask._getMetadataName, but doing so bypasses the public API and
+    # requires reconstruction of the full task just in case the dataset is
+    # config-dependent.
+    metadataDataset = pexConfig.Field(dtype=str,
+                                      doc="The dataset type of the timed top-level task's metadata, "
+                                          "such as 'processCcd_metadata'.")
+    target = pexConfig.Field(dtype=str,
+                             doc="The method to time, optionally prefixed by one or more tasks "
+                                 "in the format of `lsst.pipe.base.Task.getFullMetadata()`. "
+                                 "The times of all matching methods/tasks are added together.")
+    metric = pexConfig.Field(dtype=str,
+                             doc="The fully qualified name of the metric to store the timing information.")
+
+
+class TimingMetricTask(MetricTask):
+    """A Task that measures a timing metric using metadata produced by the
+    `lsst.pipe.base.timeMethod` decorator.
+
+    Parameters
+    ----------
+    args
+    kwargs
+        Constructor parameters are the same as for
+        `lsst.verify.compatibility.MetricTask`.
+    """
+
+    ConfigClass = TimingMetricConfig
+    _DefaultName = "timingMetric"
+
+    @classmethod
+    def _getInputMetadataKeyRoot(cls, config):
+        """Get a search string for the metadata.
+
+        The string contains the name of the target method, optionally
+        prefixed by one or more tasks in the format of
+        `lsst.pipe.base.Task.getFullMetadata()`.
+
+        Parameters
+        ----------
+        config : ``cls.ConfigClass``
+            Configuration for this task.
+
+        Returns
+        -------
+        keyRoot : `str`
+            A string identifying the class(es) and method(s) for this task.
+        """
+        return config.target
+
+    @staticmethod
+    def _searchMetadataKeys(metadata, keyFragment):
+        """Search the metadata for all keys matching a substring.
+
+        Parameters
+        ----------
+        metadata : `lsst.daf.base.PropertySet`
+            A metadata object with task-qualified keys as returned by
+            `lsst.pipe.base.Task.getFullMetadata()`.
+        keyFragment : `str`
+            A substring for a full metadata key.
+
+        Returns
+        -------
+        keys : `set` of `str`
+            All keys in ``metadata`` that have ``keyFragment`` as a substring.
+        """
+        keys = metadata.paramNames(topLevelOnly=False)
+        return {key for key in keys if keyFragment in key}
+
+    def run(self, metadata):
+        """Compute a wall-clock measurement from metadata provided by
+        `lsst.pipe.base.timeMethod`.
+
+        Parameters
+        ----------
+        metadata : iterable of `lsst.daf.base.PropertySet`
+            A collection of metadata objects, one for each unit of science
+            processing to be incorporated into this metric. Its elements
+            may be `None` to represent missing data.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            A `~lsst.pipe.base.Struct` containing the following component:
+
+            - ``measurement``: the total running time of the target method
+              across all elements of ``metadata`` (`lsst.verify.Measurement`
+              or `None`)
+
+        Raises
+        ------
+        MetricComputationError
+            Raised if any of the timing metadata are invalid.
+
+        Notes
+        -----
+        This method does not return a measurement if any element of
+        ``metadata`` is ``None``. The reason for this policy is that if a
+        science processing run was aborted without writing metadata, then any
+        timing measurement cannot be compared to other results anyway. This
+        method also does not return a measurement if no timing information was
+        provided by any of the metadata.
+        """
+        keyBase = self._getInputMetadataKeyRoot(self.config)
+        endBase = keyBase + "EndCpuTime"
+
+        timingFound = False  # some timings are indistinguishable from 0, so don't test totalTime > 0
+        totalTime = 0.0
+        for singleMetadata in metadata:
+            if singleMetadata is not None:
+                matchingKeys = TimingMetricTask._searchMetadataKeys(singleMetadata, endBase)
+                for endKey in matchingKeys:
+                    startKey = endKey.replace("EndCpuTime", "StartCpuTime")
+                    try:
+                        start, end = (singleMetadata.getAsDouble(key) for key in (startKey, endKey))
+                    except (LookupError, TypeError) as e:
+                        raise MetricComputationError("Invalid metadata") from e
+                    totalTime += end - start
+                    timingFound = True
+            else:
+                self.log.warn("At least one task run did not write metadata; aborting.")
+                return Struct(measurement=None)
+
+        if timingFound:
+            meas = Measurement(self.getOutputMetricName(self.config), totalTime * u.second)
+            meas.notes['estimator'] = 'pipe.base.timeMethod'
+        else:
+            self.log.info("Nothing to do: no timing information for %s found.", keyBase)
+            meas = None
+        return Struct(measurement=meas)
+
+    @classmethod
+    def getInputDatasetTypes(cls, config):
+        """Return input dataset types for this task.
+
+        Parameters
+        ----------
+        config : ``cls.ConfigClass``
+            Configuration for this task.
+
+        Returns
+        -------
+        metadata : `dict` from `str` to `str`
+            Dictionary from ``"metadata"`` to the dataset type of the target task's metadata.
+        """
+        return {'metadata': config.metadataDataset}
+
+    @classmethod
+    def getOutputMetricName(cls, config):
+        return Name(config.metric)

--- a/python/lsst/ap/verify/metrics.py
+++ b/python/lsst/ap/verify/metrics.py
@@ -28,6 +28,7 @@ processing of individual measurements. Measurements are handled in the
 ``ap_verify`` module or in the appropriate pipeline step, as appropriate.
 """
 
+# TODO: module deprecated by lsst.verify.compatibility.MetricsControllerTask, remove after DM-16536
 __all__ = ["AutoJob", "MetricsParser", "checkSquashReady"]
 
 import argparse


### PR DESCRIPTION
This PR implements and unit-tests a simple `lsst.verify.compatibility.MetricsTask` (see lsst/verify#30). It also switches computation of timing metrics to the prototypical `lsst.verify.compatibility.MetricsControllerTask`, while handling other metrics using `ap_verify`'s existing system.