### PR TITLE
DM-13887: Let ap_verify process multiple images per instance

### DIFF
--- a/bin/run_ci_dataset.sh
+++ b/bin/run_ci_dataset.sh
@@ -24,9 +24,8 @@
 # Simple script for running an entire dataset through ap_verify
 # Assumes that the requested dataset is already set up in EUPS
 #
-# The ap_verify workspace is a directory with the dataset name; until DM-13887
-# gets resolved, metrics are dumped to the workspace directory with names
-# containing each run's data ID.
+# The ap_verify workspace is a directory with the dataset name; metrics are
+# dumped to the workspace directory with names containing each run's data ID.
 
 set -e
 
@@ -71,7 +70,7 @@ fi
 # Would be created by ap_verify, but the OS might try to open the log first
 mkdir "${WORKSPACE}"
 
-# Store processor count (parellelism not yet implemented, see DM-13887)
+# Store processor count
 MACH=$(uname -s)
 if [[ $MACH == Darwin ]]; then
     sys_proc=$(sysctl -n hw.logicalcpu)
@@ -81,17 +80,10 @@ fi
 max_proc=8
 NUMPROC=${NUMPROC:-$((sys_proc < max_proc ? sys_proc : max_proc))}
 
-# Extract desired dataIds runs from config file
-# Workaround for DM-13887
-IDLIST="${PRODUCT_DIR}"/config/${DATASET}.list
-
-while read -r ID; do
-    echo "Running ap_verify on ${ID}..."
-    ap_verify.py --dataset "${DATASET}" \
-        --id "${ID}" \
-        --output "${WORKSPACE}" \
-        --processes "${NUMPROC}" \
-        --metrics-file "${WORKSPACE}/ap_verify.${ID}.verify.json" \
-        --silent \
-        &>> "${WORKSPACE}"/apVerify.log
-done < "${IDLIST}"
+echo "Running ap_verify on ${DATASET}..."
+ap_verify.py --dataset "${DATASET}" \
+    --output "${WORKSPACE}" \
+    --processes "${NUMPROC}" \
+    --metrics-file "${WORKSPACE}/ap_verify.{dataId}.verify.json" \
+    --silent \
+    &>> "${WORKSPACE}"/apVerify.log

--- a/config/CI-HiTS2015.list
+++ b/config/CI-HiTS2015.list
@@ -1,6 +1,0 @@
-visit=411420 ccdnum=5 filter=g
-visit=411420 ccdnum=10 filter=g
-visit=419802 ccdnum=5 filter=g
-visit=419802 ccdnum=10 filter=g
-visit=411371 ccdnum=56 filter=g
-visit=411371 ccdnum=60 filter=g

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -47,9 +47,6 @@ Required arguments are :option:`--dataset`, :option:`--id`, and :option:`--outpu
    Specify data ID to process using data ID syntax.
    For example, ``--id "visit=12345 ccd=1 filter=g"``.
    
-   Currently this argument is heavily restricted compared to its :doc:`command line task counterpart</modules/lsst.pipe.base/command-line-task-dataid-howto>`.
-   In particular, the dataId must specify exactly one visit and exactly one CCD, and may not be left blank to mean "all data".
-
 .. option:: --dataset <dataset_name>
 
    **Input dataset designation.**
@@ -73,10 +70,6 @@ Required arguments are :option:`--dataset`, :option:`--id`, and :option:`--outpu
 
    When ``processes`` is larger than 1 the pipeline may use the Python `multiprocessing` module to parallelize processing of multiple datasets across multiple processors.
    
-   .. note::
-
-      This option is provided for forward-compatibility, but is not yet supported by ``ap_verify``.
-
 .. option:: --metrics-file <filename>
 
    **Output metrics file.**

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -81,10 +81,9 @@ Required arguments are :option:`--dataset`, :option:`--id`, and :option:`--outpu
 
    **Output metrics file.**
 
-   The name of a file to contain the metrics measured by ``ap_verify``, in a format readable by the :doc:`lsst.verify</modules/lsst.verify/index>` framework.
-   If omitted, the output will go to a file named :file:`ap_verify.verify.json` in the user's working directory.
-
-   This argument can be used to run multiple instances of ``ap_verify`` concurrently, with each instance producing output to a different metrics file.
+   The template for a file to contain metrics measured by ``ap_verify``, in a format readable by the :doc:`lsst.verify</modules/lsst.verify/index>` framework.
+   The string ``{dataId}`` shall be replaced with the data ID associated with the job, and its use is strongly recommended.
+   If omitted, the output will go to files named after ``ap_verify.{dataId}.verify.json`` in the user's working directory.
 
 .. option:: --output <workspace_dir>
 

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -19,9 +19,9 @@ The basic call signature of :command:`ap_verify.py` is:
 
 .. prompt:: bash
 
-   ap_verify.py --dataset DATASET --output WORKSPACE --id DATAID
+   ap_verify.py --dataset DATASET --output WORKSPACE
 
-These three arguments are mandatory, all others are optional.
+These two arguments are mandatory, all others are optional.
 
 .. _ap-verify-cmd-return:
 
@@ -36,16 +36,15 @@ If the pipeline fails, the status code will be an interpreter-dependent nonzero 
 Named arguments
 ===============
 
-Required arguments are :option:`--dataset`, :option:`--id`, and :option:`--output`.
+Required arguments are :option:`--dataset` and :option:`--output`.
 
 .. option:: --id <dataId>
 
    **Butler data ID.**
 
-   The input data ID is required for all ``ap_verify`` runs except when using :option:`--help`.
-
    Specify data ID to process using data ID syntax.
    For example, ``--id "visit=12345 ccd=1 filter=g"``.
+   If this argument is omitted, then all data IDs in the dataset will be processed.
    
 .. option:: --dataset <dataset_name>
 

--- a/doc/lsst.ap.verify/failsafe.rst
+++ b/doc/lsst.ap.verify/failsafe.rst
@@ -27,8 +27,9 @@ Recovering Metrics From Partial Runs
 ====================================
 
 ``ap_verify`` produces some measurements even if the pipeline cannot run to completion.
-Specifically, if a task fails, any `lsst.verify.Measurement` objects created by previous top-level tasks will be :ref:`stored to disk<ap-verify-results>`.
+Specifically, if a task fails, any previously completed tasks that store measurements to disk will have done so.
+In addition, if a metric cannot be computed, ``ap_verify`` may attempt to store the values of the remaining metrics.
 Measurements from failed runs will never be submitted to SQuaSH.
 
-``ap_verify`` may not preserve measurements produced by previously completed tasks within the failed top-level task, as well as measurements computed from the dataset.
+If the pipeline fails, ``ap_verify`` may not preserve measurements computed from the dataset.
 Once the framework for handling metrics is finalized, ``ap_verify`` may be able to offer a broader guarantee that does not depend on how or where any individual metric is implemented.

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -75,14 +75,14 @@ Other options from :command:`ap_verify.py` are not available.
 How to use measurements of metrics
 ==================================
 
-After ``ap_verify`` has run, it will produce a file named, by default, :file:`ap_verify.verify.json` in the caller's directory.
+After ``ap_verify`` has run, it will produce files named, by default, :file:`ap_verify.<dataId>.verify.json` in the caller's directory.
 The file name may be customized using the :option:`--metrics-file <ap_verify.py --metrics-file>` command-line argument.
-This file contains metric measurements in ``lsst.verify`` format, and can be loaded and read as described in the :doc:`lsst.verify documentation</modules/lsst.verify/index>` or in `SQR-019 <https://sqr-019.lsst.io>`_.
+These files contain metric measurements in ``lsst.verify`` format, and can be loaded and read as described in the :doc:`lsst.verify documentation</modules/lsst.verify/index>` or in `SQR-019 <https://sqr-019.lsst.io>`_.
 
 Unless the :option:`--silent <ap_verify.py --silent>` argument is provided, ``ap_verify`` will also upload measurements to the `SQuaSH service <https://squash.lsst.codes/>`_ on completion.
 See the SQuaSH documentation for details.
 
-If the pipeline is interrupted by a fatal error, completed measurements will be saved to the metrics file for debugging purposes, but nothing will get sent to SQuaSH.
+If the pipeline is interrupted by a fatal error, completed measurements will be saved to metrics files for debugging purposes, but nothing will get sent to SQuaSH.
 See the :ref:`error-handling policy <ap-verify-failsafe-partialmetric>` for details.
 
 Further reading

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -31,12 +31,12 @@ Using the `HiTS 2015 <https://github.com/lsst/ap_verify_hits2015/>`_ dataset as 
 
 .. prompt:: bash
 
-   ap_verify.py --dataset HiTS2015 --id "visit=412518 ccdnum=25 filter=g" --output workspaces/hits/ --silent
+   ap_verify.py --dataset HiTS2015 --id "visit=412518 filter=g" --output workspaces/hits/ --silent
 
 Here the inputs are:
 
 * :command:`HiTS2015` is the :ref:`dataset name <ap-verify-dataset-name>`,
-* :command:`visit=412518 ccdnum=25 filter=g` is the :ref:`dataId<command-line-task-dataid-howto-about-dataid-keys>` to process,
+* :command:`visit=412518 filter=g` is the :ref:`dataId<command-line-task-dataid-howto-about-dataid-keys>` to process,
 
 while the output is:
 

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -130,25 +130,24 @@ class _DatasetAction(argparse.Action):
         setattr(namespace, self.dest, Dataset(values))
 
 
-def _measureFinalProperties(metricsJob, workspace, dataIds):
+def _measureFinalProperties(workspace, dataIds, args):
     """Measure any metrics that apply to the final result of the AP pipeline,
     rather than to a particular processing stage.
 
     Parameters
     ----------
-    metricsJob : `lsst.verify.Job`
-        The Job object to which to add any metric measurements made.
     workspace : `lsst.ap.verify.workspace.Workspace`
         The abstract location containing input and output repositories.
     dataIds : `lsst.pipe.base.DataIdContainer`
         The data IDs ap_pipe was run on. Each data ID must be complete.
+    args : `argparse.Namespace`
+        Command-line arguments, including arguments controlling output.
     """
-    measurements = []
     for dataId in dataIds.idList:
-        measurements.extend(measureFromButlerRepo(workspace.analysisButler, dataId))
-
-    for measurement in measurements:
-        metricsJob.measurements.insert(measurement)
+        with AutoJob(workspace.workButler, dataId, args) as metricsJob:
+            measurements = measureFromButlerRepo(workspace.analysisButler, dataId)
+            for measurement in measurements:
+                metricsJob.measurements.insert(measurement)
 
 
 def runApVerify(cmdLine=None):
@@ -174,10 +173,9 @@ def runApVerify(cmdLine=None):
     workspace = Workspace(args.output)
     ingestDataset(args.dataset, workspace)
 
-    with AutoJob(args) as job:
-        log.info('Running pipeline...')
-        expandedDataIds = runApPipe(job, workspace, args)
-        _measureFinalProperties(job, workspace, expandedDataIds)
+    log.info('Running pipeline...')
+    expandedDataIds = runApPipe(workspace, args)
+    _measureFinalProperties(workspace, expandedDataIds, args)
 
 
 def runIngestion(cmdLine=None):

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -143,9 +143,9 @@ def _measureFinalProperties(workspace, dataIds, args):
     args : `argparse.Namespace`
         Command-line arguments, including arguments controlling output.
     """
-    for dataId in dataIds.idList:
-        with AutoJob(workspace.workButler, dataId, args) as metricsJob:
-            measurements = measureFromButlerRepo(workspace.analysisButler, dataId)
+    for dataRef in dataIds.refList:
+        with AutoJob(workspace.workButler, dataRef.dataId, args) as metricsJob:
+            measurements = measureFromButlerRepo(workspace.analysisButler, dataRef.dataId)
             for measurement in measurements:
                 metricsJob.measurements.insert(measurement)
 

--- a/python/lsst/ap/verify/metrics.py
+++ b/python/lsst/ap/verify/metrics.py
@@ -76,9 +76,11 @@ class MetricsParser(argparse.ArgumentParser):
     def __init__(self):
         # Help and documentation will be handled by main program's parser
         argparse.ArgumentParser.__init__(self, add_help=False)
-        self.add_argument('--metrics-file', default='ap_verify.verify.json',
-                          help='The file to which to output metrics in lsst.verify format. '
-                               'Defaults to ap_verify.verify.json.')
+        self.add_argument(
+            '--metrics-file', default='ap_verify.{dataId}.verify.json',
+            help="The file template to which to output metrics in lsst.verify "
+                 "format; {dataId} will be replaced with the job\'s data ID. "
+                 "Defaults to ap_verify.{dataId}.verify.json.")
         self.add_argument('--silent', dest='submitMetrics', action='store_false',
                           help='Do NOT submit metrics to SQuaSH (not yet implemented).')
         # Config info we don't want on the command line
@@ -128,8 +130,11 @@ class AutoJob:
         self._job.meta.update({'instrument': _extract_instrument_from_butler(butler)})
         self._job.meta.update(dataId)
 
+        # Construct an OS-friendly string (i.e., no quotes, {}, or spaces)
+        idString = "_".join("%s%s" % (key, dataId[key]) for key in dataId)
+        self._outputFile = args.metrics_file.format(dataId=idString)
+
         self._submitMetrics = args.submitMetrics
-        self._outputFile = args.metrics_file
         self._squashUser = args.user
         self._squashPassword = args.password
         self._squashUrl = args.squashUrl

--- a/python/lsst/ap/verify/metrics.py
+++ b/python/lsst/ap/verify/metrics.py
@@ -86,6 +86,19 @@ class MetricsParser(argparse.ArgumentParser):
                           squashUrl=os.getenv(_ENV_URL, _SQUASH_DEFAULT_URL))
 
 
+# borrowed from validate_drp
+def _extract_instrument_from_butler(butler):
+    """Extract the last part of the mapper name from a Butler repo.
+    'lsst.obs.lsstSim.lsstSimMapper.LsstSimMapper' -> 'LSSTSIM'
+    'lsst.obs.cfht.megacamMapper.MegacamMapper' -> 'CFHT'
+    'lsst.obs.decam.decamMapper.DecamMapper' -> 'DECAM'
+    'lsst.obs.hsc.hscMapper.HscMapper' -> 'HSC'
+    """
+    camera = butler.get('camera')
+    instrument = camera.getName()
+    return instrument.upper()
+
+
 class AutoJob:
     """A wrapper for an `lsst.verify.Job` that automatically handles
     initialization and shutdown.
@@ -98,13 +111,23 @@ class AutoJob:
 
     Parameters
     ----------
+    butler : `lsst.daf.persistence.Butler`
+        The repository associated with this ``Job``.
+    dataId : `lsst.daf.persistence.DataId` or `dict`
+        The data ID associated with this job. Must be complete, and represent
+        the finest granularity of any measurement that may be stored in
+        this job.
     args : `argparse.Namespace`
         Command-line arguments, including all arguments supported by `MetricsParser`.
     """
 
-    def __init__(self, args):
+    def __init__(self, butler, dataId, args):
         self._job = lsst.verify.Job.load_metrics_package()
-        # TODO: add Job metadata (camera, filter, etc.) in DM-11321
+
+        #  Insert job metadata including dataId
+        self._job.meta.update({'instrument': _extract_instrument_from_butler(butler)})
+        self._job.meta.update(dataId)
+
         self._submitMetrics = args.submitMetrics
         self._outputFile = args.metrics_file
         self._squashUser = args.user
@@ -123,11 +146,6 @@ class AutoJob:
 
     def _sendToSquash(self):
         """Submit a set of measurements to the SQuaSH system.
-
-        Parameters
-        ----------
-        fileName : `str`
-            a file containing measurements in lsst.verify format
         """
         self.job.dispatch(api_user=self._squashUser, api_password=self._squashPassword,
                           api_url=self._squashUrl)

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -48,7 +48,7 @@ class ApPipeParser(argparse.ArgumentParser):
     def __init__(self):
         # Help and documentation will be handled by main program's parser
         argparse.ArgumentParser.__init__(self, add_help=False)
-        self.add_argument('--id', dest='dataId', required=True,
+        self.add_argument('--id', dest='dataId', default="",
                           help='An identifier for the data to process.')
         self.add_argument("-j", "--processes", default=1, type=int,
                           help="Number of processes to use.")
@@ -76,7 +76,10 @@ def runApPipe(workspace, parsedCmdLine):
             "--calib", workspace.calibRepo,
             "--template", workspace.templateRepo]
     args.extend(_getConfigArguments(workspace))
-    args.extend(["--id", *parsedCmdLine.dataId.split(" ")])
+    if parsedCmdLine.dataId:
+        args.extend(["--id", *parsedCmdLine.dataId.split(" ")])
+    else:
+        args.extend(["--id"])
     args.extend(["--processes", str(parsedCmdLine.processes)])
     args.extend(["--noExit"])
 

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -39,19 +39,6 @@ from lsst.pipe.base import DataIdContainer
 import lsst.ap.pipe as apPipe
 
 
-# borrowed from validate_drp
-def _extract_instrument_from_butler(butler):
-    """Extract the last part of the mapper name from a Butler repo.
-    'lsst.obs.lsstSim.lsstSimMapper.LsstSimMapper' -> 'LSSTSIM'
-    'lsst.obs.cfht.megacamMapper.MegacamMapper' -> 'CFHT'
-    'lsst.obs.decam.decamMapper.DecamMapper' -> 'DECAM'
-    'lsst.obs.hsc.hscMapper.HscMapper' -> 'HSC'
-    """
-    camera = butler.get('camera')
-    instrument = camera.getName()
-    return instrument.upper()
-
-
 class ApPipeParser(argparse.ArgumentParser):
     """An argument parser for data needed by ``ap_pipe`` activities.
 
@@ -70,14 +57,11 @@ class ApPipeParser(argparse.ArgumentParser):
                           help="Number of processes to use. Not yet implemented.")
 
 
-def runApPipe(metricsJob, workspace, parsedCmdLine):
+def runApPipe(workspace, parsedCmdLine):
     """Run `ap_pipe` on this object's dataset.
 
     Parameters
     ----------
-    metricsJob : `lsst.verify.Job`
-        The Job object to which to add any metric measurements made.
-        Currently unused.
     workspace : `lsst.ap.verify.workspace.Workspace`
         The abstract location containing input and output repositories.
     parsedCmdLine : `argparse.Namespace`
@@ -91,10 +75,6 @@ def runApPipe(metricsJob, workspace, parsedCmdLine):
     log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipe')
 
     dataId = _parseDataId(parsedCmdLine.dataId)
-
-    #  Insert job metadata including dataId
-    metricsJob.meta.update({'instrument': _extract_instrument_from_butler(workspace.workButler)})
-    metricsJob.meta.update(dataId)
 
     pipeline = apPipe.ApPipeTask(workspace.workButler, config=_getConfig(workspace))
     matchingDataRefs = dafPersist.searchDataRefs(workspace.workButler, datasetType='raw', dataId=dataId)

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -56,7 +56,7 @@ class CommandLineTestSuite(lsst.ap.verify.testUtils.DataTestCase):
     def testMissingMain(self):
         """Verify that a command line consisting missing required arguments is rejected.
         """
-        args = '--dataset %s --output tests/output/foo' % CommandLineTestSuite.datasetKey
+        args = '--id "visit=54123" --output tests/output/foo'
         with self.assertRaises(SystemExit):
             self._parseString(args)
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -79,7 +79,6 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
                                       autospec=True, dataId=self.dataIds[0])
         self.setUpMockPatch("lsst.daf.persistence.searchDataRefs", return_value=[dataRef])
 
-        self.job = lsst.verify.Job()
         self.workspace = Workspace(self._testDir)
         self.apPipeArgs = pipeline_driver.ApPipeParser().parse_args(["--id", "visit=42"])
 
@@ -123,7 +122,7 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
     def testRunApPipeSteps(self, _mockConfig, mockClass):
         """Test that runApPipe runs the entire pipeline.
         """
-        pipeline_driver.runApPipe(self.job, self.workspace, self.apPipeArgs)
+        pipeline_driver.runApPipe(self.workspace, self.apPipeArgs)
 
         mockClass.return_value.runDataRef.assert_called_once()
 
@@ -132,7 +131,7 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
     def testRunApPipeDataIdReporting(self, _mockConfig, mockClass):
         """Test that runApPipe reports the data IDs that were processed.
         """
-        ids = pipeline_driver.runApPipe(self.job, self.workspace, self.apPipeArgs)
+        ids = pipeline_driver.runApPipe(self.workspace, self.apPipeArgs)
 
         self.assertEqual(ids.idList, self.dataIds)
 
@@ -151,7 +150,7 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
                                    _DefaultName=ApPipeTask._DefaultName,
                                    ConfigClass=ApPipeTask.ConfigClass).return_value
 
-        pipeline_driver.runApPipe(self.job, self.workspace, self.apPipeArgs)
+        pipeline_driver.runApPipe(self.workspace, self.apPipeArgs)
         initCalls = (c for c in task.mock_calls if c.name == "__init__")
         for call in initCalls:
             kwargs = call[2]
@@ -169,7 +168,7 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
                                    _DefaultName=ApPipeTask._DefaultName,
                                    ConfigClass=ApPipeTask.ConfigClass).return_value
 
-        pipeline_driver.runApPipe(self.job, self.workspace, self.apPipeArgs)
+        pipeline_driver.runApPipe(self.workspace, self.apPipeArgs)
         initCalls = (c for c in task.mock_calls if c.name == "__init__")
         for call in initCalls:
             kwargs = call[2]


### PR DESCRIPTION
This PR adds multiprocessing support to `ap_verify` by making the `pipeline_driver` module call `ApPipeTask.parseAndRun` instead of `ApPipeTask.runDataRef`. This change requires a complete reorganization of how `ap_verify` passes information from `ap_pipe` to the metrics code, but as a side benefit `ap_verify` no longer needs to parse data IDs itself.