### PR TITLE
DM-16822: Use pipe.base.*DatasetConfig in MetricTask configs

### DIFF
--- a/python/lsst/ap/verify/measurements/profiling.py
+++ b/python/lsst/ap/verify/measurements/profiling.py
@@ -213,24 +213,6 @@ class TimingMetricTask(MetricTask):
             meas = None
         return Struct(measurement=meas)
 
-    # TODO: remove this once MetricTask has a generic implementation
-    @classmethod
-    def getInputDatasetTypes(cls, config):
-        """Return input dataset types for this task.
-
-        Parameters
-        ----------
-        config : ``cls.ConfigClass``
-            Configuration for this task.
-
-        Returns
-        -------
-        metadata : `dict` from `str` to `str`
-            Dictionary with one key, ``"metadata"``, mapping to the dataset
-            type of the target task's metadata.s
-        """
-        return {'metadata': config.metadata.name}
-
     @classmethod
     def getOutputMetricName(cls, config):
         return Name(config.metric)

--- a/python/lsst/ap/verify/measurements/profiling.py
+++ b/python/lsst/ap/verify/measurements/profiling.py
@@ -86,12 +86,14 @@ class TimingMetricConfig(MetricTask.ConfigClass):
         storageClass="PropertySet",
         dimensions=["Instrument", "Exposure", "Detector"],
     )
-    target = pexConfig.Field(dtype=str,
-                             doc="The method to time, optionally prefixed by one or more tasks "
-                                 "in the format of `lsst.pipe.base.Task.getFullMetadata()`. "
-                                 "The times of all matching methods/tasks are added together.")
-    metric = pexConfig.Field(dtype=str,
-                             doc="The fully qualified name of the metric to store the timing information.")
+    target = pexConfig.Field(
+        dtype=str,
+        doc="The method to time, optionally prefixed by one or more tasks "
+            "in the format of `lsst.pipe.base.Task.getFullMetadata()`. "
+            "The times of all matching methods/tasks are added together.")
+    metric = pexConfig.Field(
+        dtype=str,
+        doc="The fully qualified name of the metric to store the timing information.")
 
 
 class TimingMetricTask(MetricTask):

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -129,7 +129,7 @@ class TimingMetricTestSuite(MetricTaskTestCase):
     @staticmethod
     def _standardConfig():
         config = TimingMetricTask.ConfigClass()
-        config.metadataDataset = TimingMetricTestSuite._SCIENCE_TASK_NAME + "_metadata"
+        config.metadata.name = TimingMetricTestSuite._SCIENCE_TASK_NAME + "_metadata"
         config.target = TimingMetricTestSuite._SCIENCE_TASK_NAME + ".run"
         config.metric = "ip_isr.IsrTime"
         return config


### PR DESCRIPTION
This PR modifies `TimingMetricTask` to use `InputDatasetConfig` to specify its input metadata (which has no default value, in the hope that this class will someday be used for pipelines other than `ap_pipe`).

Because this PR changes the API, it and lsst/verify#32 must be merged together.