### PR TITLE
DM-11698: Let ap_verify support multiple --dataIdString arguments

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -44,6 +44,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
    Specify data ID to process using data ID syntax.
    For example, ``--id "visit=12345 ccd=1 filter=g"``.
+   Multiple copies of this argument are allowed.
    If this argument is omitted, then all data IDs in the dataset will be processed.
    
 .. option:: --dataset <dataset_name>

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -42,8 +42,8 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
    **Butler data ID.**
 
-   Specify data ID to process using data ID syntax.
-   For example, ``--id "visit=12345 ccd=1 filter=g"``.
+   Specify data ID to process using :doc:`data ID syntax </modules/lsst.pipe.base/command-line-task-dataid-howto>`.
+   For example, ``--id "visit=12345 ccd=1..6 filter=g"``.
    Multiple copies of this argument are allowed.
    If this argument is omitted, then all data IDs in the dataset will be processed.
    

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -46,7 +46,7 @@ class ApPipeParser(argparse.ArgumentParser):
     def __init__(self):
         # Help and documentation will be handled by main program's parser
         argparse.ArgumentParser.__init__(self, add_help=False)
-        self.add_argument('--id', dest='dataId', default="",
+        self.add_argument('--id', dest='dataIds', action='append', default=[],
                           help='An identifier for the data to process.')
         self.add_argument("-j", "--processes", default=1, type=int,
                           help="Number of processes to use.")
@@ -74,8 +74,9 @@ def runApPipe(workspace, parsedCmdLine):
             "--calib", workspace.calibRepo,
             "--template", workspace.templateRepo]
     args.extend(_getConfigArguments(workspace))
-    if parsedCmdLine.dataId:
-        args.extend(["--id", *parsedCmdLine.dataId.split(" ")])
+    if parsedCmdLine.dataIds:
+        for singleId in parsedCmdLine.dataIds:
+            args.extend(["--id", *singleId.split(" ")])
     else:
         args.extend(["--id"])
     args.extend(["--processes", str(parsedCmdLine.processes)])

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -82,8 +82,9 @@ class CommandLineTestSuite(lsst.ap.verify.testUtils.DataTestCase):
         """
         args = '--dataset %s --output tests/output/foo' % CommandLineTestSuite.datasetKey
         parsed = self._parseString(args, ap_verify._IngestOnlyParser())
-        self.assertIn('dataset', dir(parsed))
-        self.assertIn('output', dir(parsed))
+        self.assertEqual(parsed.dataset.datasetRoot,
+                         lsst.utils.getPackageDir(CommandLineTestSuite.testDataset))
+        self.assertEqual(parsed.output, "tests/output/foo")
 
     def testDataId(self):
         """Verify that a command line consisting only of required arguments parses correctly.

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -70,11 +70,12 @@ class CommandLineTestSuite(lsst.ap.verify.testUtils.DataTestCase):
     def testMinimumMain(self):
         """Verify that a command line consisting only of required arguments parses correctly.
         """
-        args = '--dataset %s --output tests/output/foo --id "visit=54123"' % CommandLineTestSuite.datasetKey
+        args = '--dataset %s --output tests/output/foo' % CommandLineTestSuite.datasetKey
         parsed = self._parseString(args)
-        self.assertIn('dataset', dir(parsed))
-        self.assertIn('output', dir(parsed))
-        self.assertIn('dataId', dir(parsed))
+        self.assertEqual(parsed.dataset.datasetRoot,
+                         lsst.utils.getPackageDir(CommandLineTestSuite.testDataset))
+        self.assertEqual(parsed.output, "tests/output/foo")
+        self.assertEqual(parsed.dataIds, [])
 
     def testMinimumIngest(self):
         """Verify that a command line consisting only of required arguments parses correctly.
@@ -83,6 +84,14 @@ class CommandLineTestSuite(lsst.ap.verify.testUtils.DataTestCase):
         parsed = self._parseString(args, ap_verify._IngestOnlyParser())
         self.assertIn('dataset', dir(parsed))
         self.assertIn('output', dir(parsed))
+
+    def testDataId(self):
+        """Verify that a command line consisting only of required arguments parses correctly.
+        """
+        args = '--dataset %s --output tests/output/foo --id "visit=54123" --id "filter=x"' \
+            % CommandLineTestSuite.datasetKey
+        parsed = self._parseString(args)
+        self.assertEqual(parsed.dataIds, ["visit=54123", "filter=x"])
 
     def testBadDataset(self):
         """Verify that a command line with an unregistered dataset is rejected.


### PR DESCRIPTION
This PR allows multiple copies of the `--id` command-line argument (the issue title is an anachronism) to be passed to `ap_verify.py`. No changes are needed to the measurement code, which sees the list of data IDs only in a highly processed form.

While this change was mostly checked with integration tests using `ap_verify_hits2015`, I've also taken the chance to improve the relevant unit tests.