### PR TITLE
DM-17543: Rename lsst.verify.compatibility to gen2tasks

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -74,7 +74,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
    **Input metrics config.**
 
-   A config file containing a `~lsst.verify.compatibility.MetricsControllerConfig`, which specifies which metrics are measured and sets any options.
+   A config file containing a `~lsst.verify.gen2tasks.MetricsControllerConfig`, which specifies which metrics are measured and sets any options.
    If this argument is omitted, :file:`config/default_metrics.py` will be used.
 
 .. option:: --metrics-file <filename>

--- a/python/lsst/ap/verify/measurements/compute_metrics.py
+++ b/python/lsst/ap/verify/measurements/compute_metrics.py
@@ -31,7 +31,7 @@ __all__ = ["measureFromButlerRepo"]
 
 import copy
 
-from lsst.verify.compatibility import MetricsControllerTask
+from lsst.verify.gen2tasks import MetricsControllerTask
 from lsst.ap.pipe import ApPipeTask
 from .association import measureNumberNewDiaObjects, \
     measureNumberUnassociatedDiaObjects, \
@@ -77,7 +77,7 @@ def measureFromButlerRepo(metricsConfig, butler, rawDataId):
     Parameters
     ----------
     metricsConfig : `str`
-        A file containing a `~lsst.verify.compatibility.MetricsControllerConfig`.
+        A file containing a `~lsst.verify.gen2tasks.MetricsControllerConfig`.
     butler : `lsst.daf.persistence.Butler`
         A butler opened to the repository to read.
     rawDataId : `lsst.daf.persistence.DataId` or `dict`
@@ -123,8 +123,8 @@ def _runMetricTasks(config, butler, dataId):
 
     Parameters
     ----------
-    config : `lsst.verify.compatibility.MetricsControllerConfig`
-        The config for running `~lsst.verify.compatibility.MetricsControllerTask`.
+    config : `lsst.verify.gen2tasks.MetricsControllerConfig`
+        The config for running `~lsst.verify.gen2tasks.MetricsControllerTask`.
     butler : `lsst.daf.persistence.Butler`
         A butler opened to ap_verify's output repository.
     dataId : `lsst.daf.persistence.DataId` or `dict`

--- a/python/lsst/ap/verify/measurements/profiling.py
+++ b/python/lsst/ap/verify/measurements/profiling.py
@@ -33,7 +33,7 @@ import astropy.units as u
 import lsst.pex.config as pexConfig
 from lsst.pipe.base import Struct, InputDatasetField
 from lsst.verify import Measurement, Name, MetricComputationError
-from lsst.verify.compatibility import registerMultiple, MetricTask
+from lsst.verify.gen2tasks import registerMultiple, MetricTask
 
 
 def measureRuntime(metadata, taskName, metricName):
@@ -106,7 +106,7 @@ class TimingMetricTask(MetricTask):
     args
     kwargs
         Constructor parameters are the same as for
-        `lsst.verify.compatibility.MetricTask`.
+        `lsst.verify.gen2tasks.MetricTask`.
     """
 
     ConfigClass = TimingMetricConfig

--- a/python/lsst/ap/verify/metrics.py
+++ b/python/lsst/ap/verify/metrics.py
@@ -28,7 +28,7 @@ processing of individual measurements. Measurements are handled in the
 ``ap_verify`` module or in the appropriate pipeline step, as appropriate.
 """
 
-# TODO: module deprecated by lsst.verify.compatibility.MetricsControllerTask, remove after DM-16536
+# TODO: module deprecated by lsst.verify.gen2tasks.MetricsControllerTask, remove after DM-16536
 __all__ = ["AutoJob", "MetricsParser", "checkSquashReady"]
 
 import argparse

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -31,7 +31,7 @@ import lsst.utils.tests
 import lsst.afw.image as afwImage
 from lsst.ip.isr import FringeTask
 from lsst.verify import Measurement, Name, MetricComputationError
-from lsst.verify.compatibility.testUtils import MetricTaskTestCase
+from lsst.verify.gen2tasks.testUtils import MetricTaskTestCase
 
 from lsst.ap.verify.measurements.profiling import measureRuntime, TimingMetricTask
 


### PR DESCRIPTION
In lsst/verify#35, `lsst.verify.compatiblity` is renamed to `lsst.verify.gen2tasks`. This PR updates `ap_veify` for this breaking API change.