### PR TITLE
DM-17248: ap_verify should create .json files in the workspace by default

### DIFF
--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -66,7 +66,8 @@ class Workspace:
 
     @property
     def configDir(self):
-        """The location of a directory containing custom Task config files for use with the data.
+        """The location of a directory containing custom Task config files for
+        use with the data (`str`, read-only).
         """
         return os.path.join(self._location, 'config')
 

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -65,6 +65,12 @@ class Workspace:
         self._analysisButler = None
 
     @property
+    def workDir(self):
+        """The location of the workspace as a whole (`str`, read-only).
+        """
+        return self._location
+
+    @property
     def configDir(self):
         """The location of a directory containing custom Task config files for
         use with the data (`str`, read-only).

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -49,7 +49,7 @@ class WorkspaceTestSuite(lsst.utils.tests.TestCase):
         self.assertEqual(ancestor, _canonDir)
 
     def _assertNotInDir(self, path, baseDir):
-        """Test that ``path`` is a subpath of ``baseDir``.
+        """Test that ``path`` is not a subpath of ``baseDir``.
         """
         _canonPath = os.path.abspath(os.path.realpath(path))
         _canonDir = os.path.abspath(os.path.realpath(baseDir))

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -84,6 +84,7 @@ class WorkspaceTestSuite(lsst.utils.tests.TestCase):
         The exact repository locations are not tested, as they are likely to change.
         """
         root = self._testWorkspace
+        self.assertEqual(self._testbed.workDir, root)
         self._assertInDir(self._testbed.configDir, root)
         for repo in WorkspaceTestSuite._allRepos(self._testbed):
             # Workspace spec allows these to be URIs or paths, whatever the Butler accepts


### PR DESCRIPTION
This PR modifies the default location of `ap_verify`'s output `Job` files to the workspace created by `--output`. This change is backwards-compatible with scripts that explicitly assign a location.