### PR TITLE
Remove lsst.ap.verify.measurements automodapi

### DIFF
--- a/doc/lsst.ap.verify/index.rst
+++ b/doc/lsst.ap.verify/index.rst
@@ -48,6 +48,3 @@ Python API reference
 .. automodapi:: lsst.ap.verify
    :no-main-docstr:
    :no-inheritance-diagram:
-.. automodapi:: lsst.ap.verify.measurements
-   :no-main-docstr:
-   :no-inheritance-diagram:


### PR DESCRIPTION
The lsst.ap.verify.measurements sub package was dropped in DM-18490.