### PR TITLE
DM-20570: Pipeline failure treated as ap_verify success

### DIFF
--- a/bin.src/ap_verify.py
+++ b/bin.src/ap_verify.py
@@ -22,7 +22,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import sys
 from lsst.ap.verify import runApVerify
 
 if __name__ == "__main__":
-    runApVerify()
+    result = runApVerify()
+    sys.exit(result)

--- a/bin.src/ingest_dataset.py
+++ b/bin.src/ingest_dataset.py
@@ -22,7 +22,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import sys
 from lsst.ap.verify import runIngestion
 
 if __name__ == "__main__":
-    runIngestion()
+    result = runIngestion()
+    sys.exit(result)

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -28,8 +28,8 @@ These two arguments are mandatory, all others are optional.
 Status code
 ===========
 
-:command:`ap_verify.py` returns a status code of ``0`` if the pipeline ran to completion.
-If the pipeline fails, the status code will be an interpreter-dependent nonzero value.
+Like :ref:`command-line tasks <command-line-task-argument-reference>`, :command:`ap_verify.py` returns the number of data IDs that could not be processed (i.e., 0 on a complete success).
+However, an uncaught exception causes :command:`ap_verify.py` to return an interpreter-dependent nonzero value instead (also as for command-line tasks).
 
 .. _ap-verify-cmd-args:
 

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -152,8 +152,8 @@ def runApVerify(cmdLine=None):
     ingestDataset(args.dataset, workspace)
 
     log.info('Running pipeline...')
-    expandedDataIds = runApPipe(workspace, args)
-    computeMetrics(workspace, expandedDataIds, args)
+    apPipeResults = runApPipe(workspace, args)
+    computeMetrics(workspace, apPipeResults.parsedCmd.id, args)
 
 
 def runIngestion(cmdLine=None):

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -65,8 +65,9 @@ def runApPipe(workspace, parsedCmdLine):
 
     Returns
     -------
-    dataIds : `lsst.pipe.base.DataIdContainer`
-        The set of complete data IDs fed into ``ap_pipe``.
+    apPipeReturn : `Struct`
+        The `Struct` returned from `~lsst.ap.pipe.ApPipeTask.parseAndRun` with
+        ``doReturnResults=False``.
     """
     log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipe')
 
@@ -89,7 +90,7 @@ def runApPipe(workspace, parsedCmdLine):
     results = apPipe.ApPipeTask.parseAndRun(pipelineArgs)
     log.info('Pipeline complete')
 
-    return results.parsedCmd.id
+    return results
 
 
 def _getConfigArguments(workspace):

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -52,7 +52,7 @@ def patchApPipe(method):
             argumentParser=None,
             parsedCmd=parsedCmd,
             taskRunner=None,
-            resultList=[None])
+            resultList=[Struct(exitStatus=0)])
         dbPatcher = unittest.mock.patch("lsst.ap.verify.pipeline_driver.makePpdb")
         pipePatcher = unittest.mock.patch("lsst.ap.pipe.ApPipeTask",
                                           **{"parseAndRun.return_value": parReturn},

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -123,7 +123,8 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
     def testRunApPipeDataIdReporting(self, _mockDb, _mockClass):
         """Test that runApPipe reports the data IDs that were processed.
         """
-        ids = pipeline_driver.runApPipe(self.workspace, self.apPipeArgs)
+        results = pipeline_driver.runApPipe(self.workspace, self.apPipeArgs)
+        ids = results.parsedCmd.id
 
         self.assertEqual(ids.idList, _getDataIds())
 


### PR DESCRIPTION
This PR propagates pipeline status information from the `ApPipeTask` wrapper to the main function, where it can be returned to the shell as if for a command-line task. This fixes a bug where `ap_verify.py` would return 0 after catastrophic pipeline failure and the Jenkins run would be marked as successful.

I think `ap_verify`'s exit code is correctly propagated from `run_ci_dataset.sh` up to Jenkins, but I'm not sure how to test that. :confused: 