### PR TITLE
DM-20251: Improve documentation for how to register metrics with ap_verify

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -9,6 +9,7 @@ ap_verify command-line reference
 ################################
 
 This page describes the command-line arguments and environment variables used by :command:`ap_verify.py`.
+See :doc:`running` for an overview.
 
 .. _ap-verify-cmd-basic:
 
@@ -51,12 +52,12 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
    **Input dataset designation.**
 
-   The input dataset is required for all ``ap_verify`` runs except when using :option:`--help`.
+   The :doc:`input dataset <datasets>` is required for all ``ap_verify`` runs except when using :option:`--help`.
 
    The argument is a unique name for the dataset, which can be associated with a repository in the :ref:`configuration file<ap-verify-configuration-dataset>`.
    See :ref:`ap-verify-dataset-name` for more information on dataset names.
 
-   Allowed names can be queried using the :option:`--help` argument.
+   :ref:`Allowed names <ap-verify-datasets-index>` can be queried using the :option:`--help` argument.
 
 .. option:: --dataset-metrics-config <filename>
 
@@ -66,6 +67,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    If this argument is omitted, :file:`config/default_dataset_metrics.py` will be used.
 
    Use :option:`--image-metrics-config` to configure image-level metrics instead.
+   See also :doc:`new-metrics`.
 
 .. option:: -h, --help
 
@@ -87,6 +89,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    If this argument is omitted, :file:`config/default_image_metrics.py` will be used.
 
    Use :option:`--dataset-metrics-config` to configure dataset-level metrics instead.
+   See also :doc:`new-metrics`.
 
 .. option:: --metrics-file <filename>
 

--- a/doc/lsst.ap.verify/configuration.rst
+++ b/doc/lsst.ap.verify/configuration.rst
@@ -1,5 +1,7 @@
 .. py:currentmodule:: lsst.ap.verify
 
+.. program:: ap_verify.py
+
 .. _ap-verify-configuration:
 
 ######################################
@@ -18,6 +20,11 @@ Most users should not need to adjust these settings, but they allow capabilities
 datasets
 ========
 
-The ``datasets`` dictionary maps dataset names (which must be provided on the :command:`ap_verify.py` command line) to GitHub repository names.
+The ``datasets`` dictionary maps dataset names (which must be provided through :option:`ap_verify.py --dataset`) to GitHub repository names.
 Adding a dataset to the config is necessary for ``ap_verify`` to recognize it; in practice, the entry will be made once by the dataset author and then committed.
 A dataset must still be :doc:`installed<datasets-install>` on the machine before it can be used.
+
+Further reading
+===============
+
+- :doc:`datasets`

--- a/doc/lsst.ap.verify/configuration.rst
+++ b/doc/lsst.ap.verify/configuration.rst
@@ -7,10 +7,11 @@ ap_verify configuration file reference
 ######################################
 
 This page describes the file-based configuration options used by ``ap_verify``.
-Most users should not need to adjust these settings, but they allow capabilities such as registering new :doc:`datasets<datasets>`.
+It does *not* describe the configuration of ``MetricTask``\ s for ``ap_verify``; see :doc:`new-metrics` instead.
 
 The ``ap_verify`` configuration file is located at :file:`config/dataset_config.yaml`.
 It consists of a list of dictionaries, each representing specific aspects of the program.
+Most users should not need to adjust these settings, but they allow capabilities such as registering new :doc:`datasets<datasets>`.
 
 .. _ap-verify-configuration-dataset:
 

--- a/doc/lsst.ap.verify/datasets-butler.rst
+++ b/doc/lsst.ap.verify/datasets-butler.rst
@@ -6,7 +6,7 @@
 Datasets vs. Butler repositories
 ################################
 
-Datasets are organized using a :ref:`specific directory structure<ap-verify-datasets-structure>` instead of an :ref:`LSST Butler repository<butler>`.
+:doc:`Datasets <datasets>` are organized using a :ref:`specific directory structure<ap-verify-datasets-structure>` instead of an :ref:`LSST Butler repository<butler>`.
 This is by design:
 :ref:`ingestion of observatory files into a repository<ingest>` is considered part of the pipeline system being tested by ``ap_verify``, so ``ap_verify`` must be fed uningested data as its input.
 The ingestion step creates a valid repository that is then used by the rest of the pipeline.
@@ -14,6 +14,6 @@ The ingestion step creates a valid repository that is then used by the rest of t
 A secondary benefit of this approach is that dataset maintainers do not need to manually ensure that the Git repository associated with a dataset remains a valid Butler repository despite changes to the dataset.
 The dataset format merely requires that files be segregated into science and calibration directories, a much looser integrity constraint.
 
-While datasets are not Butler repositories themselves, the dataset format includes a directory, :file:`repo`, that serves as a template for the post-ingestion repository.
+While datasets are not Butler repositories themselves, the dataset format includes a directory, :file:`repo`, that serves as a template for :ref:`repositories created by ap_verify.py <ap-verify-run-output>`.
 This template helps ensure that all repositories based on the dataset will be properly set up, in particular that any observatory-specific settings will be applied.
 :file:`repo` is never modified by ``ap_verify``; all repositories created by the pipeline must be located elsewhere, whether or not they are backed by the file system.

--- a/doc/lsst.ap.verify/datasets-creation.rst
+++ b/doc/lsst.ap.verify/datasets-creation.rst
@@ -57,7 +57,7 @@ Configuring dataset ingestion
 
 Each dataset's :file:`config` directory should contain a :ref:`task config file<command-line-task-config-howto-configfile>` named :file:`datasetIngest.py`, which specifies a `DatasetIngestConfig`.
 The file typically contains filenames or file patterns specific to the dataset.
-In particular, defect files and reference catalogs are ignored by default and need to be explicitly named.
+In particular, reference catalogs are ignored by default and need to be explicitly named.
 
 Each :file:`config` directory may contain a task config file named :file:`apPipe.py`, specifying an `lsst.ap.pipe.ApPipeConfig`.
 The file contains pipeline flags specific to the dataset, such as the available reference catalogs or information about how its image differencing templates were generated.

--- a/doc/lsst.ap.verify/datasets-creation.rst
+++ b/doc/lsst.ap.verify/datasets-creation.rst
@@ -52,15 +52,15 @@ The dataset's package-level documentation should include:
 
 .. _ap-verify-datasets-creation-config:
 
-Configuring dataset ingestion
-=============================
+Configuring dataset ingestion and use
+=====================================
 
 Each dataset's :file:`config` directory should contain a :ref:`task config file<command-line-task-config-howto-configfile>` named :file:`datasetIngest.py`, which specifies a `DatasetIngestConfig`.
 The file typically contains filenames or file patterns specific to the dataset.
-In particular, reference catalogs are ignored by default and need to be explicitly named.
+In particular, the default config ignores reference catalogs, so the config file should provide a ``dict`` from catalog names to their tar files.
 
 Each :file:`config` directory may contain a task config file named :file:`apPipe.py`, specifying an `lsst.ap.pipe.ApPipeConfig`.
-The file contains pipeline flags specific to the dataset, such as the available reference catalogs or information about how its image differencing templates were generated.
+The file contains pipeline flags specific to the dataset, such as the available reference catalogs (both their names and configuration) or the type of template provided to `~lsst.pipe.tasks.imageDifference.ImageDifferenceTask`.
 
 Configuration settings specific to an instrument rather than a dataset should be handled with ordinary :ref:`configuration override files<command-line-task-config-howto-obs>`.
 

--- a/doc/lsst.ap.verify/datasets-creation.rst
+++ b/doc/lsst.ap.verify/datasets-creation.rst
@@ -1,5 +1,7 @@
 .. py:currentmodule:: lsst.ap.verify
 
+.. program:: ap_verify.py
+
 .. _ap-verify-datasets-creation:
 
 .. _ap-verify-datasets-structure:
@@ -82,6 +84,6 @@ The observatory package must be named in two files:
 Registering a dataset name
 ==========================
 
-In order to be supported by ``ap_verify``, datasets must be registered in ``ap_verify``'s :ref:`configuration file<ap-verify-configuration-dataset>`.
+In order to be recognized by :option:`ap_verify.py --dataset`, datasets must be registered in ``ap_verify``'s :ref:`configuration file<ap-verify-configuration-dataset>`.
 The line for the new dataset should be committed to the ``ap_verify`` Git repository.
 To avoid accidental downloads, datasets **should not** be registered as an EUPS dependency of ``ap_verify``, even an optional one.

--- a/doc/lsst.ap.verify/datasets-install.rst
+++ b/doc/lsst.ap.verify/datasets-install.rst
@@ -1,5 +1,7 @@
 .. py:currentmodule:: lsst.ap.verify
 
+.. program:: ap_verify.py
+
 .. _ap-verify-datasets-install:
 
 ###################
@@ -34,4 +36,9 @@ For example, to install the `HiTS 2015 <https://github.com/lsst/ap_verify_hits20
 
    rebuild -u ap_verify_hits2015
 
-Once this is done, ``ap_verify`` will be able to find the HiTS data upon request.
+Once this is done, ``ap_verify`` will be able to find the HiTS data when requested through :option:`--dataset`.
+
+Further reading
+===============
+
+- :doc:`running`

--- a/doc/lsst.ap.verify/datasets.rst
+++ b/doc/lsst.ap.verify/datasets.rst
@@ -37,8 +37,10 @@ In depth
 Existing datasets
 =================
 
-* `HiTS2015 <https://github.com/lsst/ap_verify_hits2015/>`_
-* `HiTS2015 CI Subset <https://github.com/lsst/ap_verify_ci_hits2015/>`_
+These datasets are also listed when running :option:`ap_verify.py -h`.
+
+* `HiTS2015 (HiTS 2015 with 2014 templates) <https://github.com/lsst/ap_verify_hits2015/>`_
+* `CI-HiTS2015 (HiTS 2015 CI Subset) <https://github.com/lsst/ap_verify_ci_hits2015/>`_
 
 ..
    TODO: switch to toctree once these docs included in pipelines.lsst.io

--- a/doc/lsst.ap.verify/failsafe.rst
+++ b/doc/lsst.ap.verify/failsafe.rst
@@ -6,7 +6,7 @@
 Error-handling in ap_verify and failed runs
 ###########################################
 
-The Alert Production pipeline may fail for reasons ranging from corrupted data to improperly configured datasets to bugs in the code.
+The Alert Production pipeline may fail for reasons ranging from corrupted data to :ref:`improperly configured datasets <ap-verify-datasets-creation-config>` to bugs in the code.
 The ``ap_verify`` framework tries to handle failures gracefully to minimize wasted server time and maximize debugging potential.
 
 .. _ap-verify-failsafe-catch:
@@ -23,7 +23,7 @@ In particular, where possible it will :ref:`preserve metrics<ap-verify-failsafe-
 
 .. _ap-verify-failsafe-partialmetric:
 
-Recovering Metrics From Partial Runs
+Recovering metrics from partial runs
 ====================================
 
 ``ap_verify`` produces some measurements even if the pipeline cannot run to completion.
@@ -32,3 +32,8 @@ In addition, if a metric cannot be computed, ``ap_verify`` may attempt to store 
 
 If the pipeline fails, ``ap_verify`` may not preserve measurements computed from the dataset.
 Once the framework for handling metrics is finalized, ``ap_verify`` may be able to offer a broader guarantee that does not depend on how or where any individual metric is implemented.
+
+Further reading
+===============
+
+- :doc:`running`

--- a/doc/lsst.ap.verify/index.rst
+++ b/doc/lsst.ap.verify/index.rst
@@ -11,7 +11,7 @@ It runs the alert production pipeline (encapsulated in the :doc:`lsst.ap.pipe </
 
 ``ap_verify`` is designed to work with small, standardized :doc:`datasets<datasets>` that can be interchanged to test the Stack's performance under different conditions.
 To ensure consistent results, it :doc:`runs the entire AP pipeline<running>` as a single unit, from data ingestion to source association.
-It produces measurements, using the :doc:`lsst.verify</modules/lsst.verify/index>` framework, that can be used for both monitoring stack development and debugging failure cases.
+It produces :doc:`metric <new-metrics>` values, using the :doc:`lsst.verify</modules/lsst.verify/index>` framework, that can be used for both monitoring stack development and debugging failure cases.
 
 .. _lsst.ap.verify-using:
 

--- a/doc/lsst.ap.verify/index.rst
+++ b/doc/lsst.ap.verify/index.rst
@@ -24,6 +24,7 @@ Using lsst.ap.verify
    running
    datasets
    failsafe
+   new-metrics
    command-line-reference
    configuration
 
@@ -34,11 +35,6 @@ Contributing
 
 ``lsst.ap.verify`` is developed at https://github.com/lsst/ap_verify.
 You can find Jira issues for this module under the `ap_verify <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ap_verify>`_ component.
-
-.. toctree::
-   :maxdepth: 1
-
-   new-metrics
 
 .. _lsst.ap.verify-pyapi:
 

--- a/doc/lsst.ap.verify/new-metrics.rst
+++ b/doc/lsst.ap.verify/new-metrics.rst
@@ -19,3 +19,11 @@ Typically, a file configures each metric through ``config.measurers[<name>]``; s
 The ``ap_verify`` package provides two config files in the :file:`config/` directory, which define the image- and dataset-level configs that are run by default (for example, during CI).
 These files feature complex logic to minimize code duplication and minimize the work in adding new metrics.
 This complexity is not required by ``MetricsControllerTask``; a config that's just a list of assignments will also work.
+
+Further reading
+===============
+
+- :doc:`running`
+- :doc:`failsafe`
+- :lsst-task:`lsst.verify.gen2tasks.MetricTask`
+- :lsst-task:`lsst.verify.gen2tasks.MetricsControllerTask`

--- a/doc/lsst.ap.verify/new-metrics.rst
+++ b/doc/lsst.ap.verify/new-metrics.rst
@@ -4,9 +4,9 @@
 
 .. _ap-verify-new-metrics:
 
-##################################
-Registering metrics with ap_verify
-##################################
+#################################
+Configuring metrics for ap_verify
+#################################
 
 ``ap_verify`` handles metrics through the :lsst-task:`~lsst.verify.gen2tasks.metricTask.MetricTask` framework.
 Each metric has an associated :lsst-task:`~lsst.verify.gen2tasks.metricTask.MetricTask`, typically in the package associated with the metric.

--- a/doc/lsst.ap.verify/new-metrics.rst
+++ b/doc/lsst.ap.verify/new-metrics.rst
@@ -14,7 +14,7 @@ For example, the code for computing ``ip_diffim.numSciSources`` can be found in 
 
 The metrics computed by ``ap_verify`` are configured through two command-line options, :option:`--image-metrics-config` and :option:`--dataset-metrics-config`.
 These options each take a config file for a `~lsst.verify.gen2tasks.metricsControllerTask.MetricsControllerConfig`, the former for metrics that are computed over individual images and the latter for metrics that apply to the entire dataset.
-Typically, a file configures each metric through ``config.measurers[<name>]``; see the documentation for :lsst-task:`~lsst.verify.gen2tasks.metricsControllerTask.MetricsControllerTask` for examples.
+Typically, a file configures each metric through ``config.measurers[<name>]``; see the documentation for :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` for examples.
 
 The ``ap_verify`` package provides two config files in the :file:`config/` directory, which define the image- and dataset-level configs that are run by default (for example, during CI).
 These files feature complex logic to minimize code duplication and minimize the work in adding new metrics.

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -31,12 +31,12 @@ Using the `HiTS 2015 <https://github.com/lsst/ap_verify_hits2015/>`_ dataset as 
 
 .. prompt:: bash
 
-   ap_verify.py --dataset HiTS2015 --id "visit=412518 filter=g" --output workspaces/hits/
+   ap_verify.py --dataset HiTS2015 --id "visit=412518^412568 filter=g" --output workspaces/hits/
 
 Here the inputs are:
 
 * :command:`HiTS2015` is the :ref:`dataset name <ap-verify-dataset-name>`,
-* :command:`visit=412518 filter=g` is the :ref:`dataId<command-line-task-dataid-howto-about-dataid-keys>` to process,
+* :command:`visit=412518^412568 filter=g` is the :ref:`dataId<command-line-task-dataid-howto-about-dataid-keys>` to process,
 
 while the output is:
 
@@ -44,10 +44,15 @@ while the output is:
 
 This call will create a new directory at :file:`workspaces/hits`, ingest the HiTS data into a new repository based on :file:`<hits-data>/repo/`, then run visit 412518 through the entire AP pipeline.
 
+It's also possible to run an entire dataset by omitting the :command:`--id` argument (as some datasets are very large, do this with caution):
+
+.. prompt:: bash
+
+   ap_verify.py --dataset CI-HiTS2015 --output workspaces/hits/
+
 .. note::
 
-   The command-line interface for :command:`ap_verify.py` is at present much more limited than those of command-line tasks.
-   In particular, only file-based repositories are supported, and compound dataIds cannot be provided.
+   The command-line interface for :command:`ap_verify.py` is at present more limited than those of command-line tasks.
    See the :doc:`command-line-reference` for details.
 
 .. _ap-verify-run-ingest:

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -8,7 +8,7 @@ Running ap_verify from the command line
 
 :command:`ap_verify.py` is a Python script designed to be run on both developer machines and verification servers.
 While :command:`ap_verify.py` is not a :doc:`command-line task</modules/lsst.pipe.base/index>`, the command-line interface is designed to resemble that of command-line tasks where practical.
-This page describes the minimum options needed to run ``ap_verify``.
+This page describes the most common options used to run ``ap_verify``.
 For more details, see the :doc:`command-line-reference` or run :option:`ap_verify.py -h`.
 
 .. _ap-verify-dataset-name:
@@ -18,7 +18,7 @@ Datasets as input arguments
 
 Since ``ap_verify`` begins with an uningested :doc:`dataset<datasets>`, the input argument is a dataset name rather than a repository.
 
-Datasets are identified by a name that gets mapped to an :doc:`eups-registered directory <datasets-install>` containing the data.
+Datasets are identified by a name that gets mapped to an :doc:`installed eups-registered package <datasets-install>` containing the data.
 The mapping is :ref:`configurable<ap-verify-configuration-dataset>`.
 The dataset names are a placeholder for a future data repository versioning system, and may be replaced in a later version of ``ap_verify``.
 
@@ -60,7 +60,7 @@ It's also possible to run an entire dataset by omitting the :command:`--id` argu
 How to run ingestion by itself
 ==============================
 
-``ap_verify`` includes a separate program, :command:`ingest_dataset.py`, that ingests datasets but does not run the pipeline on them.
+``ap_verify`` includes a separate program, :command:`ingest_dataset.py`, that :doc:`ingests datasets into repositories <datasets-butler>` but does not run the pipeline on them.
 This is useful if the data need special processing or as a precursor to massive processing runs.
 Running :command:`ap_verify.py` with the same arguments as a previous run of :command:`ingest_dataset.py` will automatically skip ingestion.
 
@@ -89,4 +89,6 @@ Further reading
 ===============
 
 - :doc:`datasets-install`
+- :doc:`new-metrics`
+- :doc:`failsafe`
 - :doc:`command-line-reference`


### PR DESCRIPTION
This PR reorganizes the config documentation to make coverage of the metric configs more prominent. The details of what the configs should look like are deferred to [the `MetricsControllerTask` task page](https://pipelines.lsst.io/v/daily/modules/lsst.verify/tasks/lsst.verify.gen2tasks.MetricsControllerTask.html).

The PR also fixes a number of other documentation bugs that were too small to warrant their own issue.