### PR TITLE
DM-21877: Create "marker" Butler dataset for PPDB

### DIFF
--- a/config/default_dataset_metrics.py
+++ b/config/default_dataset_metrics.py
@@ -1,11 +1,6 @@
-from lsst.verify.tasks import ConfigApdbLoader
 # Import these modules to ensure the metrics are registered
+import lsst.verify.tasks  # noqa: F401
 import lsst.ap.association.metrics  # noqa: F401
 
 apdbConfigs = ["totalUnassociatedDiaObjects"]
 config.measurers = apdbConfigs
-
-# List comprehension would be cleaner, but can't refer to config inside one
-for subConfig in apdbConfigs:
-    config.measurers[subConfig].dbLoader.retarget(ConfigApdbLoader)
-    config.measurers[subConfig].connections.taskName = "apPipe"


### PR DESCRIPTION
The PR removes the custom config for `PpdbMetricTask` (name change pending; see [DM-22039](https://jira.lsstcorp.org/browse/DM-22039)). After lsst/verify#57, the input dataset type is no longer pipeline-dependent, so it's safe to use the default.