### PR TITLE
DM-24259: Create “stub“ Gen2 HSC dataset for CI testing

### DIFF
--- a/config/dataset_config.yaml
+++ b/config/dataset_config.yaml
@@ -2,4 +2,5 @@
 datasets:
     HiTS2015: ap_verify_hits2015
     CI-HiTS2015: ap_verify_ci_hits2015
+    CI-CosmosPDR2: ap_verify_ci_cosmos_pdr2
 ...

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -49,7 +49,8 @@ class Workspace:
     """
 
     def __init__(self, location):
-        self._location = location
+        # Properties must be `str` for backwards compatibility
+        self._location = str(pathlib.Path(location).resolve())
 
         mode = stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH  # a+r, u+rwx
         kwargs = {"parents": True, "exist_ok": True, "mode": mode}
@@ -66,45 +67,50 @@ class Workspace:
 
     @property
     def workDir(self):
-        """The location of the workspace as a whole (`str`, read-only).
+        """The absolute location of the workspace as a whole
+        (`str`, read-only).
         """
         return self._location
 
     @property
     def configDir(self):
-        """The location of a directory containing custom Task config files for
-        use with the data (`str`, read-only).
+        """The absolute location of a directory containing custom Task config
+        files for use with the data (`str`, read-only).
         """
         return os.path.join(self._location, 'config')
 
     @property
     def dataRepo(self):
-        """The URI to a Butler repo for science data (`str`, read-only).
+        """The absolute path/URI to a Butler repo for science data
+        (`str`, read-only).
         """
         return os.path.join(self._location, 'ingested')
 
     @property
     def calibRepo(self):
-        """The URI to a Butler repo for calibration data (`str`, read-only).
+        """The absolute path/URI to a Butler repo for calibration data
+        (`str`, read-only).
         """
         return os.path.join(self._location, 'calibingested')
 
     @property
     def templateRepo(self):
-        """The URI to a Butler repo for precomputed templates (`str`, read-only).
+        """The absolute path/URI to a Butler repo for precomputed templates
+        (`str`, read-only).
         """
         return self.dataRepo
 
     @property
     def outputRepo(self):
-        """The URI to a Butler repo for AP pipeline products (`str`, read-only).
+        """The absolute path/URI to a Butler repo for AP pipeline products
+        (`str`, read-only).
         """
         return os.path.join(self._location, 'output')
 
     @property
     def dbLocation(self):
-        """The default location of the source association database to be
-        created or updated by the pipeline (`str`, read-only).
+        """The default absolute location of the source association database to
+        be created or updated by the pipeline (`str`, read-only).
 
         Shall be a filename to a database file suitable
         for the sqlite backend of `Apdb`.

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -83,7 +83,8 @@ class WorkspaceTestSuite(lsst.utils.tests.TestCase):
 
         The exact repository locations are not tested, as they are likely to change.
         """
-        root = self._testWorkspace
+        # Workspace should report all paths as absolute
+        root = os.path.abspath(os.path.realpath(self._testWorkspace))
         self.assertEqual(self._testbed.workDir, root)
         self._assertInDir(self._testbed.configDir, root)
         for repo in WorkspaceTestSuite._allRepos(self._testbed):


### PR DESCRIPTION
This PR adds the dataset added by lsst/ap_verify_ci_cosmos_pdr2#1. It also changes all repository paths to absolute to work around various issues in the Gen 2 butler and the Gen 2 to Gen 3 conversion script.