### PR TITLE
DM-24523: ap.verify.ingestion._findMatchingFiles excludes directories

### DIFF
--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -33,7 +33,6 @@ import fnmatch
 import os
 import shutil
 import tarfile
-from contextlib import contextmanager
 from glob import glob
 import sqlite3
 
@@ -510,34 +509,3 @@ def _findMatchingFiles(basePath, include, exclude=None):
         excludedFiles = [f for f in allFiles if fnmatch.fnmatch(os.path.basename(f), pattern)]
         allFiles.difference_update(excludedFiles)
     return allFiles
-
-
-@contextmanager
-def _tempChDir(newDir):
-    """Change to a new directory, while avoiding side effects in external code.
-
-    Note that no side effects are guaranteed in the case of normal operation or
-    for exceptions raised by the body of a ``with`` statement, but not for
-    exceptions raised by ``_tempChDir`` itself (see below).
-
-    This context manager cannot be used with "with ... as" statements.
-
-    Parameters
-    ----------
-    newDir : `str`
-        The directory to change to for the duration of a ``with`` statement.
-
-    Raises
-    ------
-    OSError
-        Raised if either the program cannot change to ``newDir``, or if it
-        cannot undo the change. Failing to change to ``newDir`` is
-        exception-safe (no side effects), but failing to undo is
-        not recoverable.
-    """
-    startDir = os.path.abspath(os.getcwd())
-    os.chdir(newDir)
-    try:
-        yield
-    finally:
-        os.chdir(startDir)

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -507,7 +507,8 @@ def _findMatchingFiles(basePath, include, exclude=None):
         allFiles.update(glob(os.path.join(basePath, '**', pattern), recursive=True))
 
     for pattern in _exclude:
-        allFiles.difference_update(fnmatch.filter(allFiles, pattern))
+        excludedFiles = [f for f in allFiles if fnmatch.fnmatch(os.path.basename(f), pattern)]
+        allFiles.difference_update(excludedFiles)
     return allFiles
 
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -363,15 +363,15 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
              {'raw_v1_fg.fits.gz', 'raw_v2_fg.fits.gz', 'raw_v3_fr.fits.gz'}}
         )
         self.assertSetEqual(
-            ingestion._findMatchingFiles(testDir, ['raw_*.fits.gz'], ['*fr*']),
+            ingestion._findMatchingFiles(testDir, ['raw_*.fits.gz'], exclude=['*fr*']),
             {os.path.join(testDir, 'raw', f) for f in {'raw_v1_fg.fits.gz', 'raw_v2_fg.fits.gz'}}
         )
         self.assertSetEqual(
-            ingestion._findMatchingFiles(testDir, ['raw_*.fits.gz'], ['*_v?_f?.fits.gz']),
+            ingestion._findMatchingFiles(testDir, ['raw_*.fits.gz'], exclude=['*_v?_f?.fits.gz']),
             set()
         )
         self.assertSetEqual(
-            ingestion._findMatchingFiles(testDir, ['raw_*.fits.gz'], ['obs_test']),
+            ingestion._findMatchingFiles(testDir, ['raw_*.fits.gz'], exclude=['obs_test']),
             {os.path.join(testDir, 'raw', f) for f in
              {'raw_v1_fg.fits.gz', 'raw_v2_fg.fits.gz', 'raw_v3_fr.fits.gz'}}
         )

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -370,6 +370,11 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
             ingestion._findMatchingFiles(testDir, ['raw_*.fits.gz'], ['*_v?_f?.fits.gz']),
             set()
         )
+        self.assertSetEqual(
+            ingestion._findMatchingFiles(testDir, ['raw_*.fits.gz'], ['obs_test']),
+            {os.path.join(testDir, 'raw', f) for f in
+             {'raw_v1_fg.fits.gz', 'raw_v2_fg.fits.gz', 'raw_v3_fr.fits.gz'}}
+        )
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
This PR fixes a bug where filename filters meant to exclude certain files excluded certain directories instead. It also performs some cleanup of the affected code.