### PR TITLE
DM-24844: Migrate ap_verify_testdata to obs_lsst

### DIFF
--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -95,8 +95,10 @@ class DatasetIngestConfig(pexConfig.Config):
 
     textDefectPath = pexConfig.Field(
         dtype=str,
-        default='',
-        doc="Path to top level of the defect tree.  This is a directory with a directory per sensor."
+        default=None,
+        optional=True,
+        doc="Path to top level of the defect tree.  This is a directory with a directory per sensor. "
+            "Set to None to disable defect ingestion."
     )
     defectIngester = pexConfig.ConfigurableField(
         target=IngestCuratedCalibsTask,
@@ -300,7 +302,7 @@ class DatasetIngestTask(pipeBase.Task):
         """
         if os.path.exists(os.path.join(workspace.calibRepo, "defects")):
             self.log.info("Defects were previously ingested, skipping...")
-        else:
+        elif self.config.textDefectPath:
             self.log.info("Ingesting defects...")
             self._doIngestDefects(workspace.dataRepo, workspace.calibRepo, self.config.textDefectPath)
             self.log.info("Defects are now ingested in {0}".format(workspace.calibRepo))
@@ -316,7 +318,7 @@ class DatasetIngestTask(pipeBase.Task):
             The output repository location on disk for calibration files. Must
             exist.
         defectPath : `str`
-            Path to the defects in standard text form.  This is probably a path in ``obs_decam_data``.
+            Path to the defects in standard text form.  This is probably a path in ``obs_*_data``.
 
         Raises
         ------

--- a/tests/ingestion/repoTemplate/_mapper
+++ b/tests/ingestion/repoTemplate/_mapper
@@ -1,1 +1,0 @@
-lsst.obs.test.testMapper.TestMapper

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -37,8 +37,8 @@ class DatasetTestSuite(DataTestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.obsPackage = 'obs_test'
-        cls.camera = 'test'
+        cls.obsPackage = 'obs_lsst'
+        cls.camera = 'imsim'
 
     def setUp(self):
         self._testbed = Dataset(DatasetTestSuite.datasetKey)

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -69,6 +69,7 @@ class IngestionTestSuite(lsst.utils.tests.TestCase):
 
         cls.mockCamera = MockCamera(MockDetector())
         cls.config = cls.makeTestConfig()
+        cls.config.validate()
         cls.config.freeze()
 
         cls.testApVerifyData = os.path.join('tests', 'ingestion')

--- a/ups/ap_verify.table
+++ b/ups/ap_verify.table
@@ -8,7 +8,6 @@ setupRequired(ap_pipe)
 
 # For testing
 setupOptional(ap_verify_testdata)
-setupOptional(obs_test)
 
 # For default metric configs
 setupRequired(ip_diffim)


### PR DESCRIPTION
This PR updates all unit tests to use `ap_verify_testdata` instead of `obs_test` (the ingestion tests rely heavily on details of the specific files in the dataset, and had to be rewritten almost entirely). It also fixes several bugs revealed by the use of ImSim datasets.