### PR TITLE
DM-25407: ap_verify cannot handle curated crosstalk data in Gen 2

### DIFF
--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -93,12 +93,11 @@ class DatasetIngestConfig(pexConfig.Config):
         default=9999,
         doc="Calibration validity period (days). Assumed equal for all calib types.")
 
-    curatedCalibPaths = pexConfig.Field(
+    curatedCalibPaths = pexConfig.ListField(
         dtype=str,
-        default=None,
-        optional=True,
-        doc="Path to top level of the defect tree.  This is a directory with a directory per sensor. "
-            "Set to None to disable defect ingestion."
+        default=[],
+        doc="Paths to the top level of each curated calib's tree (e.g., defects, crosstalk). "
+            "Each path should be a directory which contains one subdirectory per sensor."
     )
     curatedCalibIngester = pexConfig.ConfigurableField(
         target=IngestCuratedCalibsTask,
@@ -295,10 +294,9 @@ class DatasetIngestTask(pipeBase.Task):
         workspace : `lsst.ap.verify.workspace.Workspace`
             The location containing all ingestion repositories.
         """
-        if self.config.curatedCalibPaths:
+        for curated in self.config.curatedCalibPaths:
             self.log.info("Ingesting curated calibs...")
-            self._doIngestCuratedCalibs(workspace.dataRepo, workspace.calibRepo,
-                                        self.config.curatedCalibPaths)
+            self._doIngestCuratedCalibs(workspace.dataRepo, workspace.calibRepo, curated)
             self.log.info("Curated calibs are now ingested in {0}".format(workspace.calibRepo))
 
     def _doIngestCuratedCalibs(self, repo, calibRepo, curatedPath):

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -84,7 +84,7 @@ class IngestionTestSuite(DataTestCase):
         config.dataIngester.load(os.path.join(obsDir, 'ingest.py'))
         config.dataIngester.load(os.path.join(obsDir, 'imsim', 'ingest.py'))
         config.calibIngester.load(os.path.join(obsDir, 'ingestCalibs.py'))
-        config.defectIngester.load(os.path.join(obsDir, 'ingestCuratedCalibs.py'))
+        config.curatedCalibIngester.load(os.path.join(obsDir, 'ingestCuratedCalibs.py'))
         return config
 
     def setUp(self):


### PR DESCRIPTION
This PR does a bulk removal of all references to "defects" in `DatasetIngestTask`, removing some out-of-date documentation in the process. It then modifies the code to take a (possibly empty) list of curated calib directories, allowing more than one type of curated calib to be ingested at a time.

I ended up sacrificing the code that guards against repeated ingestion of defects. It should be possible to make the check more generic (auto-detecting what the ingested files should look like), but I'm putting that off until [DM-25414](https://jira.lsstcorp.org/browse/DM-25414) to get things merged today.