### PR TITLE
DM-20922: ap_verify can't handle --id with empty argument

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -46,6 +46,8 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    Specify data ID to process using :doc:`data ID syntax </modules/lsst.pipe.base/command-line-task-dataid-howto>`.
    For example, ``--id "visit=12345 ccd=1..6 filter=g"``.
    Multiple copies of this argument are allowed.
+   For compatibility with the syntax used by command line tasks, ``--id`` with no argument processes all data IDs.
+
    If this argument is omitted, then all data IDs in the dataset will be processed.
    
 .. option:: --dataset <dataset_name>

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -87,7 +87,8 @@ class CommandLineTestSuite(lsst.ap.verify.testUtils.DataTestCase):
         self.assertEqual(parsed.output, "tests/output/foo")
 
     def testDataId(self):
-        """Verify that a command line consisting only of required arguments parses correctly.
+        """Verify that a command line consisting only of required arguments and
+        --id parses correctly.
         """
         args = '--dataset %s --output tests/output/foo --id "visit=54123" --id "filter=x"' \
             % CommandLineTestSuite.datasetKey

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -94,6 +94,19 @@ class CommandLineTestSuite(lsst.ap.verify.testUtils.DataTestCase):
         parsed = self._parseString(args)
         self.assertEqual(parsed.dataIds, ["visit=54123", "filter=x"])
 
+    def testEmptyDataId(self):
+        """Test that an --id argument may be not followed by a data ID.
+        """
+        minArgs = f'--dataset {self.datasetKey} --output tests/output/foo'
+
+        # Nothing after --id
+        parsed = self._parseString(minArgs + ' --id')
+        self.assertEqual(parsed.dataIds, [])
+
+        # --dataset immediately after --id
+        parsed = self._parseString('--id ' + minArgs)
+        self.assertEqual(parsed.dataIds, [])
+
     def testBadDataset(self):
         """Verify that a command line with an unregistered dataset is rejected.
         """


### PR DESCRIPTION
This PR lets callers of `ap_verify.py` use `--id` by itself, with no data ID, without changing the existing behavior when omitting `--id` or using it with a string argument.