### PR TITLE
DM-21915: Support Gen 3 ingestion of ap_verify datasets

### DIFF
--- a/bin/run_ci_dataset.sh
+++ b/bin/run_ci_dataset.sh
@@ -82,6 +82,7 @@ NUMPROC=${NUMPROC:-$((sys_proc < max_proc ? sys_proc : max_proc))}
 
 echo "Running ap_verify on ${DATASET}..."
 ap_verify.py --dataset "${DATASET}" \
+    --gen2 \    # TODO: generalize in DM-24262
     --output "${WORKSPACE}" \
     --processes "${NUMPROC}" \
     --metrics-file "${WORKSPACE}/ap_verify.{dataId}.verify.json" \

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -22,7 +22,7 @@ The basic call signature of :command:`ap_verify.py` is:
 
    ap_verify.py --dataset DATASET --output WORKSPACE
 
-These two arguments are mandatory, all others are optional.
+These two arguments are mandatory, all others are optional (though use of either :option:`--gen2` or :option:`--gen3` is highly recommended).
 
 .. _ap-verify-cmd-return:
 
@@ -70,6 +70,20 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
    Use :option:`--image-metrics-config` to configure image-level metrics instead.
    See also :doc:`new-metrics`.
+
+.. option:: --gen2
+.. option:: --gen3
+
+   **Choose Gen 2 or Gen 3 processing.**
+
+   These optional flags run either the Gen 2 pipeline (`~lsst.ap.pipe.ApPipeTask`), or the Gen 3 pipeline (:file:`apPipe.yaml`).
+   If neither flag is provided, the Gen 2 pipeline will be run.
+
+   .. note::
+
+      The current default is provided for backward-compatibility with old scripts that assumed Gen 2 processing.
+      The default will change to ``--gen3`` once Gen 3 processing is officially supported by the Science Pipelines, at which point Gen 2 support will be deprecated.
+      Until the default stabilizes, users should be explicit about which pipeline they wish to run.
 
 .. option:: -h, --help
 

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -1,5 +1,7 @@
 .. py:currentmodule:: lsst.ap.verify
 
+.. program:: ap_verify.py
+
 .. _ap-verify-running:
 
 #######################################
@@ -70,7 +72,7 @@ Using the `HiTS 2015 <https://github.com/lsst/ap_verify_hits2015/>`_ dataset as 
 
    ingest_dataset.py --dataset HiTS2015 --output workspaces/hits/
 
-The :option:`--dataset <ap_verify.py --dataset>` and :option:`--output <ap_verify.py --output>` arguments behave the same way as for :command:`ap_verify.py`.
+The :option:`--dataset` and :option:`--output` arguments behave the same way as for :command:`ap_verify.py`.
 Other options from :command:`ap_verify.py` are not available.
 
 .. _ap-verify-results:
@@ -79,7 +81,7 @@ How to use measurements of metrics
 ==================================
 
 After ``ap_verify`` has run, it will produce files named, by default, :file:`ap_verify.<dataId>.verify.json` in the caller's directory.
-The file name may be customized using the :option:`--metrics-file <ap_verify.py --metrics-file>` command-line argument.
+The file name may be customized using the :option:`--metrics-file` command-line argument.
 These files contain metric measurements in ``lsst.verify`` format, and can be loaded and read as described in the :doc:`lsst.verify documentation</modules/lsst.verify/index>` or in `SQR-019 <https://sqr-019.lsst.io>`_.
 
 If the pipeline is interrupted by a fatal error, completed measurements will be saved to metrics files for debugging purposes.

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -33,11 +33,12 @@ Using the `HiTS 2015 <https://github.com/lsst/ap_verify_hits2015/>`_ dataset as 
 
 .. prompt:: bash
 
-   ap_verify.py --dataset HiTS2015 --id "visit=412518^412568 filter=g" --output workspaces/hits/
+   ap_verify.py --dataset HiTS2015 --gen2 --id "visit=412518^412568 filter=g" --output workspaces/hits/
 
 Here the inputs are:
 
-* :command:`HiTS2015` is the :ref:`dataset name <ap-verify-dataset-name>`,
+* :command:`HiTS2015` is the ``ap_verify`` :ref:`dataset name <ap-verify-dataset-name>`,
+* :option:`--gen2` specifies to process the dataset using the Gen 2 pipeline framework,
 * :command:`visit=412518^412568 filter=g` is the :ref:`dataId<command-line-task-dataid-howto-about-dataid-keys>` to process,
 
 while the output is:
@@ -50,7 +51,7 @@ It's also possible to run an entire dataset by omitting the :command:`--id` argu
 
 .. prompt:: bash
 
-   ap_verify.py --dataset CI-HiTS2015 --output workspaces/hits/
+   ap_verify.py --dataset CI-HiTS2015 --gen2 --output workspaces/hits/
 
 .. note::
 
@@ -70,9 +71,9 @@ Using the `HiTS 2015 <https://github.com/lsst/ap_verify_hits2015/>`_ dataset as 
 
 .. prompt:: bash
 
-   ingest_dataset.py --dataset HiTS2015 --output workspaces/hits/
+   ingest_dataset.py --dataset HiTS2015 --gen2 --output workspaces/hits/
 
-The :option:`--dataset` and :option:`--output` arguments behave the same way as for :command:`ap_verify.py`.
+The :option:`--dataset`, :option:`--output`, :option:`--gen2`, and :option:`--gen3` arguments behave the same way as for :command:`ap_verify.py`.
 Other options from :command:`ap_verify.py` are not available.
 
 .. _ap-verify-results:

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -38,7 +38,7 @@ from .dataset import Dataset
 from .ingestion import ingestDataset, ingestDatasetGen3
 from .metrics import MetricsParser, computeMetrics
 from .pipeline_driver import ApPipeParser, runApPipe
-from .workspace import Workspace
+from .workspace import WorkspaceGen2, WorkspaceGen3
 
 
 class _InputOutputParser(argparse.ArgumentParser):
@@ -162,7 +162,7 @@ def runApVerify(cmdLine=None):
     args = _ApVerifyParser().parse_args(args=cmdLine)
     log.debug('Command-line arguments: %s', args)
 
-    workspace = Workspace(args.output)
+    workspace = WorkspaceGen2(args.output)
     ingestDataset(args.dataset, workspace)
 
     log.info('Running pipeline...')
@@ -214,8 +214,9 @@ def runIngestion(cmdLine=None):
     args = _IngestOnlyParser().parse_args(args=cmdLine)
     log.debug('Command-line arguments: %s', args)
 
-    workspace = Workspace(args.output)
     if args.useGen3:
+        workspace = WorkspaceGen3(args.output)
         ingestDatasetGen3(args.dataset, workspace)
     else:
+        workspace = WorkspaceGen2(args.output)
         ingestDataset(args.dataset, workspace)

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -77,7 +77,7 @@ class _IngestOnlyParser(argparse.ArgumentParser):
     def __init__(self):
         argparse.ArgumentParser.__init__(
             self,
-            description='Ingests a dataset into a pair of Butler repositories.'
+            description='Ingests an ap_verify dataset into a pair of Butler repositories. '
             'The program will create a data repository in <OUTPUT>/ingested and a calib repository '
             'in <OUTPUT>/calibingested. '
             'These repositories may be used directly by ap_verify.py by '

--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -34,9 +34,9 @@ class Dataset:
     """A dataset supported by ``ap_verify``.
 
     Any object of this class is guaranteed to represent a ready-for-use
-    dataset, barring concurrent changes to the file system or EUPS operations.
-    Constructing a Dataset does not create a compatible output repository(ies),
-    which can be done by calling `makeCompatibleRepo`.
+    ap_verify dataset, barring concurrent changes to the file system or EUPS
+    operations. Constructing a Dataset does not create a compatible output
+    repository(ies), which can be done by calling `makeCompatibleRepo`.
 
     Parameters
     ----------
@@ -48,8 +48,8 @@ class Dataset:
     RuntimeError
         Raised if `datasetId` exists, but is not correctly organized or incomplete
     ValueError
-        Raised if `datasetId` is not a recognized dataset. No side effects if this
-        exception is raised.
+        Raised if `datasetId` is not a recognized ap_verify dataset. No side
+        effects if this exception is raised.
     """
 
     def __init__(self, datasetId):
@@ -74,7 +74,7 @@ class Dataset:
         self._initPackage(datasetPackage)
 
     def _initPackage(self, name):
-        """Prepare the package backing this dataset.
+        """Prepare the package backing this ap_verify dataset.
 
         Parameters
         ----------
@@ -86,7 +86,7 @@ class Dataset:
 
     @staticmethod
     def getSupportedDatasets():
-        """The dataset IDs that can be passed to this class's constructor.
+        """The ap_verify dataset IDs that can be passed to this class's constructor.
 
         Returns
         -------
@@ -104,7 +104,7 @@ class Dataset:
 
     @staticmethod
     def _getDatasetInfo():
-        """Return external data on supported datasets.
+        """Return external data on supported ap_verify datasets.
 
         If an exception is raised, the program state shall be unchanged.
 
@@ -122,7 +122,8 @@ class Dataset:
 
     @property
     def datasetRoot(self):
-        """The parent directory containing everything related to the dataset (`str`, read-only).
+        """The parent directory containing everything related to the
+        ap_verify dataset (`str`, read-only).
         """
         return self._dataRootDir
 
@@ -153,19 +154,19 @@ class Dataset:
 
     @property
     def configLocation(self):
-        """The directory containing configs that can be used to process the dataset (`str`, read-only).
+        """The directory containing configs that can be used to process the data (`str`, read-only).
         """
         return os.path.join(self.datasetRoot, 'config')
 
     @property
     def obsPackage(self):
-        """The name of the obs package associated with this dataset (`str`, read-only).
+        """The name of the obs package associated with this data (`str`, read-only).
         """
         return Butler.getMapperClass(self._stubInputRepo).getPackageName()
 
     @property
     def camera(self):
-        """The name of the camera associated with this dataset (`str`, read-only).
+        """The name of the camera associated with this data (`str`, read-only).
         """
         return Butler.getMapperClass(self._stubInputRepo).getCameraName()
 
@@ -205,7 +206,7 @@ class Dataset:
             raise RuntimeError('Stub repo at ' + self._stubInputRepo + 'is missing mapper file')
 
     def makeCompatibleRepo(self, repoDir, calibRepoDir):
-        """Set up a directory as a repository compatible with this dataset.
+        """Set up a directory as a repository compatible with this ap_verify dataset.
 
         If the directory already exists, any files required by the dataset will
         be added if absent; otherwise the directory will remain unchanged.

--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -23,7 +23,7 @@
 
 import os
 
-from lsst.daf.persistence import Butler
+import lsst.daf.persistence as dafPersistence
 import lsst.pex.exceptions as pexExcept
 from lsst.utils import getPackageDir
 
@@ -162,13 +162,13 @@ class Dataset:
     def obsPackage(self):
         """The name of the obs package associated with this data (`str`, read-only).
         """
-        return Butler.getMapperClass(self._stubInputRepo).getPackageName()
+        return dafPersistence.Butler.getMapperClass(self._stubInputRepo).getPackageName()
 
     @property
     def camera(self):
         """The name of the camera associated with this data (`str`, read-only).
         """
-        return Butler.getMapperClass(self._stubInputRepo).getCameraName()
+        return dafPersistence.Butler.getMapperClass(self._stubInputRepo).getCameraName()
 
     @property
     def _stubInputRepo(self):
@@ -206,7 +206,7 @@ class Dataset:
             raise RuntimeError('Stub repo at ' + self._stubInputRepo + 'is missing mapper file')
 
     def makeCompatibleRepo(self, repoDir, calibRepoDir):
-        """Set up a directory as a repository compatible with this ap_verify dataset.
+        """Set up a directory as a Gen 2 repository compatible with this ap_verify dataset.
 
         If the directory already exists, any files required by the dataset will
         be added if absent; otherwise the directory will remain unchanged.
@@ -221,11 +221,11 @@ class Dataset:
         mapperArgs = {'mapperArgs': {'calibRoot': calibRepoDir}}
         if _isRepo(self.templateLocation):
             # Stub repo is not a parent because can't mix v1 and v2 repositories in parents list
-            Butler(inputs=[{"root": self.templateLocation, "mode": "r"}],
-                   outputs=[{"root": repoDir, "mode": "rw", **mapperArgs}])
+            dafPersistence.Butler(inputs=[{"root": self.templateLocation, "mode": "r"}],
+                                  outputs=[{"root": repoDir, "mode": "rw", **mapperArgs}])
         else:
-            Butler(inputs=[{"root": self._stubInputRepo, "mode": "r"}],
-                   outputs=[{"root": repoDir, "mode": "rw", **mapperArgs}])
+            dafPersistence.Butler(inputs=[{"root": self._stubInputRepo, "mode": "r"}],
+                                  outputs=[{"root": repoDir, "mode": "rw", **mapperArgs}])
 
 
 def _isRepo(repoDir):

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -27,7 +27,7 @@ This module handles ingestion of an ap_verify dataset into an appropriate reposi
 that pipeline code need not be aware of the dataset framework.
 """
 
-__all__ = ["DatasetIngestConfig", "Gen3DatasetIngestConfig", "ingestDataset"]
+__all__ = ["DatasetIngestConfig", "Gen3DatasetIngestConfig", "ingestDataset", "ingestDatasetGen3"]
 
 import fnmatch
 import os
@@ -447,7 +447,7 @@ class Gen3DatasetIngestTask(pipeBase.Task):
     """
 
     ConfigClass = Gen3DatasetIngestConfig
-    _DefaultName = "datasetIngest"
+    _DefaultName = "gen3DatasetIngest"
 
     def __init__(self, dataset, workspace, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -531,14 +531,14 @@ class Gen3DatasetIngestTask(pipeBase.Task):
 
 
 def ingestDataset(dataset, workspace):
-    """Ingest the contents of a dataset into a Butler repository.
+    """Ingest the contents of an ap_veify dataset into a Butler repository.
 
     The original data directory shall not be modified.
 
     Parameters
     ----------
     dataset : `lsst.ap.verify.dataset.Dataset`
-        The dataset to be ingested.
+        The ap_verify dataset to be ingested.
     workspace : `lsst.ap.verify.workspace.Workspace`
         The abstract location where ingestion repositories will be created.
         If the repositories already exist, they must be compatible with
@@ -550,6 +550,26 @@ def ingestDataset(dataset, workspace):
 
     ingester = DatasetIngestTask(config=_getConfig(DatasetIngestTask, dataset))
     ingester.run(dataset, workspace)
+    log.info("Data ingested")
+
+
+def ingestDatasetGen3(dataset, workspace):
+    """Ingest the contents of an ap_verify dataset into a Gen 3 Butler repository.
+
+    The original data directory is not modified.
+
+    Parameters
+    ----------
+    dataset : `lsst.ap.verify.dataset.Dataset`
+        The ap_verify dataset to be ingested.
+    workspace : `lsst.ap.verify.workspace.Workspace`
+        The abstract location where the epository is be created, if it does
+        not already exist.
+    """
+    log = lsst.log.Log.getLogger("ap.verify.ingestion.ingestDataset")
+
+    ingester = Gen3DatasetIngestTask(dataset, workspace, config=_getConfig(Gen3DatasetIngestTask, dataset))
+    ingester.run()
     log.info("Data ingested")
 
 

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -417,28 +417,32 @@ def ingestDataset(dataset, workspace):
     # TODO: generalize to support arbitrary URIs (DM-11482)
     log = lsst.log.Log.getLogger("ap.verify.ingestion.ingestDataset")
 
-    ingester = DatasetIngestTask(config=_getConfig(dataset))
+    ingester = DatasetIngestTask(config=_getConfig(DatasetIngestTask, dataset))
     ingester.run(dataset, workspace)
     log.info("Data ingested")
 
 
-def _getConfig(dataset):
+def _getConfig(task, dataset):
     """Return the ingestion config associated with a specific dataset.
 
     Parameters
     ----------
+    task : `lsst.pipe.base.Task`-type
+        The task whose config is needed
     dataset : `lsst.ap.verify.dataset.Dataset`
         The dataset whose ingestion config is desired.
 
     Returns
     -------
-    config : `DatasetIngestConfig`
-        The config for running `DatasetIngestTask` on ``dataset``.
+    config : ``task.ConfigClass``
+        The config for running ``task`` on ``dataset``.
     """
-    overrideFile = DatasetIngestTask._DefaultName + ".py"
+    # Can't use dataset.instrument.applyConfigOverrides for this, because the
+    # dataset might not have Gen 3 support.
+    overrideFile = task._DefaultName + ".py"
     packageDir = lsst.utils.getPackageDir(dataset.obsPackage)
 
-    config = DatasetIngestTask.ConfigClass()
+    config = task.ConfigClass()
     for path in [
         os.path.join(packageDir, 'config'),
         os.path.join(packageDir, 'config', dataset.camera),

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -78,7 +78,7 @@ def runApPipe(workspace, parsedCmdLine):
 
     Parameters
     ----------
-    workspace : `lsst.ap.verify.workspace.Workspace`
+    workspace : `lsst.ap.verify.workspace.WorkspaceGen2`
         The abstract location containing input and output repositories.
     parsedCmdLine : `argparse.Namespace`
         Command-line arguments, including all arguments supported by `ApPipeParser`.

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -131,6 +131,25 @@ class CommandLineTestSuite(lsst.ap.verify.testUtils.DataTestCase):
         with self.assertRaises(SystemExit):
             self._parseString(args, ap_verify._IngestOnlyParser())
 
+    def testGen23Selector(self):
+        """Verify that all combinations of --gen2 and --gen3 behave
+        as expected.
+        """
+        minArgs = f'--dataset {self.datasetKey} --output tests/output/foo '
+
+        # Default currently Gen 2, will become Gen 3 later
+        parsedDefault = self._parseString(minArgs)
+        self.assertFalse(parsedDefault.useGen3)
+
+        parsedGen2 = self._parseString(minArgs + '--gen2')
+        self.assertFalse(parsedGen2.useGen3)
+
+        parsedGen3 = self._parseString(minArgs + '--gen3')
+        self.assertTrue(parsedGen3.useGen3)
+
+        with self.assertRaises(SystemExit):
+            self._parseString(minArgs + '--gen2 --gen3')
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -33,7 +33,7 @@ from lsst.pipe.base import DataIdContainer, Struct
 import lsst.utils.tests
 from lsst.ap.pipe import ApPipeTask
 from lsst.ap.verify import pipeline_driver
-from lsst.ap.verify.workspace import Workspace
+from lsst.ap.verify.workspace import WorkspaceGen2
 
 
 def _getDataIds():
@@ -71,7 +71,7 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
         # Fake Butler to avoid Workspace initialization overhead
         self.setUpMockPatch("lsst.daf.persistence.Butler", autospec=True)
 
-        self.workspace = Workspace(self._testDir)
+        self.workspace = WorkspaceGen2(self._testDir)
         self.apPipeArgs = pipeline_driver.ApPipeParser().parse_args(
             ["--id", "visit=%d" % _getDataIds()[0]["visit"]])
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -32,7 +32,7 @@ import lsst.pipe.tasks as pipeTasks
 from lsst.ap.verify import ingestion
 from lsst.ap.verify.testUtils import DataTestCase
 from lsst.ap.verify.dataset import Dataset
-from lsst.ap.verify.workspace import Workspace
+from lsst.ap.verify.workspace import WorkspaceGen2, WorkspaceGen3
 
 
 class MockDetector(object):
@@ -124,7 +124,7 @@ class IngestionTestSuite(DataTestCase):
         self._dataset = Dataset(self.datasetKey)
         # Fake Workspace because it's too hard to make a real one with a fake Butler
         self._workspace = unittest.mock.NonCallableMock(
-            spec=Workspace,
+            spec=WorkspaceGen2,
             dataRepo=self._repo,
             calibRepo=self._calibRepo,
         )
@@ -344,11 +344,11 @@ class IngestionTestSuiteGen3(DataTestCase):
 
         self.root = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
-        self.workspace = Workspace(self.root)
+        self.workspace = WorkspaceGen3(self.root)
         self.task = ingestion.Gen3DatasetIngestTask(config=self.config,
                                                     dataset=self.dataset, workspace=self.workspace)
 
-        self.butler = self.workspace.gen3WorkButler
+        self.butler = self.workspace.workButler
 
     def assertIngestedDataFiles(self, data, collection):
         """Test that data have been loaded into a specific collection.

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -373,7 +373,6 @@ class IngestionTestSuiteGen3(DataTestCase):
                                                                      dataId=dataId)]
             self.assertNotEqual(matches, [])
 
-    @unittest.skip("Not yet implemented")
     def testDataIngest(self):
         """Test that ingesting science images given specific files adds them to a repository.
         """
@@ -381,21 +380,26 @@ class IngestionTestSuiteGen3(DataTestCase):
         self.task._ingestRaws(files)
         self.assertIngestedDataFiles(self.rawData, self.dataset.instrument.makeDefaultRawIngestRunName())
 
-    @unittest.skip("Not yet implemented")
+    def testDataDoubleIngest(self):
+        """Test that re-ingesting science images raises RuntimeError.
+        """
+        files = [os.path.join(self.dataset.rawLocation, datum['file']) for datum in self.rawData]
+        self.task._ingestRaws(files)
+        with self.assertRaises(RuntimeError):
+            self.task._ingestRaws(files)
+
     def testDataIngestDriver(self):
         """Test that ingesting science images starting from an abstract dataset adds them to a repository.
         """
         self.task._ensureRaws()
         self.assertIngestedDataFiles(self.rawData, self.dataset.instrument.makeDefaultRawIngestRunName())
 
-    @unittest.skip("Not yet implemented")
     def testCalibIngestDriver(self):
         """Test that ingesting calibrations starting from an abstract dataset adds them to a repository.
         """
         self.task._ensureRaws()  # Should not affect calibs, but would be run
         self.assertIngestedDataFiles(self.calibData, self.dataset.instrument.makeCollectionName("calib"))
 
-    @unittest.skip("Not yet implemented")
     def testNoFileIngest(self):
         """Test that attempts to ingest nothing raise an exception.
         """

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -406,6 +406,14 @@ class IngestionTestSuiteGen3(DataTestCase):
         with self.assertRaises(RuntimeError):
             self.task._ingestRaws([])
 
+    def testCopyConfigs(self):
+        """Test that "ingesting" configs stores them in the workspace for later reference.
+        """
+        self.task._copyConfigs()
+        self.assertTrue(os.path.exists(self.workspace.configDir))
+        # Only testdata file that *must* be supported in the future
+        self.assertTrue(os.path.exists(os.path.join(self.workspace.configDir, "datasetIngest.py")))
+
     def testFindMatchingFiles(self):
         """Test that _findMatchingFiles finds the desired files.
         """

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -285,7 +285,7 @@ class IngestionTestSuite(DataTestCase):
         self._registerTask.addRow.assert_not_called()
 
     def testBadFileIngest(self):
-        """Test that ingestion of raw data ignores blacklisted files.
+        """Test that ingestion of raw data ignores forbidden files.
         """
         badFiles = ['raw_v2_fg.fits.gz']
         self.setUpRawRegistry()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -101,6 +101,13 @@ class WorkspaceTestSuite(lsst.utils.tests.TestCase):
             # Workspace spec allows these to be URIs or paths, whatever the Butler accepts
             self._assertNotInDir(self._testbed.dbLocation, url2pathname(repo))
 
+    def testButlerError(self):
+        """Verify that the Gen 3 Butler is not available if the repository is
+        not set up.
+        """
+        with self.assertRaises(RuntimeError):
+            self._testbed.gen3WorkButler
+
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
This PR adds a completely separate Gen 3 channel to the `ap.verify.ingestion` module, with corresponding changes to other `ap_verify` classes. Parallel classes have led to some duplication of code, but it will make migration easier to think about if the Gen 2 and Gen 3 codebases do not depend on each other.

`Dataset` is a Gen-agnostic class, since a downloaded dataset can contain data formatted for both Gen 2 and Gen 3, making the distinction an artificial one. `Workspace` has been given separate classes for Gen 2 and Gen 3 because it was the simplest way to get a clean separation of Gen 2 and 3 elements (conceptually, a workspace is created for a particular processing run, and is therefore either Gen 2 or Gen 3). Of course, `DatasetIngestTask` has completely different Gen 2 and Gen 3 implementations, and merging them into one class would be both difficult and confusing.