### PR TITLE
DM-25970: ap_verify CI command line broken

### DIFF
--- a/bin/run_ci_dataset.sh
+++ b/bin/run_ci_dataset.sh
@@ -81,8 +81,9 @@ max_proc=8
 NUMPROC=${NUMPROC:-$((sys_proc < max_proc ? sys_proc : max_proc))}
 
 echo "Running ap_verify on ${DATASET}..."
+# TODO: let caller choose --gen2 or --gen3 in DM-24262
 ap_verify.py --dataset "${DATASET}" \
-    --gen2 \    # TODO: generalize in DM-24262
+    --gen2 \
     --output "${WORKSPACE}" \
     --processes "${NUMPROC}" \
     --metrics-file "${WORKSPACE}/ap_verify.{dataId}.verify.json" \


### PR DESCRIPTION
This PR fixes a comment that was causing most of the {{ap_verify.py}} command line to be truncated.