### PR TITLE
DM-26070: Add visit definition to ap_verify

### DIFF
--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -408,6 +408,34 @@ class IngestionTestSuiteGen3(DataTestCase):
         with self.assertRaises(RuntimeError):
             self.task._ingestRaws([])
 
+    def testVisitDefinition(self):
+        """Test that the final repository supports indexing by visit.
+        """
+        self.task._ensureRaws()
+        self.task._defineVisits()
+
+        testId = {"visit": self.VISIT_ID, "instrument": self.INSTRUMENT, }
+        exposures = list(self.butler.registry.queryDimensions("exposure", dataId=testId))
+        self.assertEqual(len(exposures), 1)
+        self.assertEqual(exposures[0]["exposure"], self.VISIT_ID)
+
+    def testVisitDoubleDefinition(self):
+        """Test that re-defining visits is guarded against.
+        """
+        self.task._ensureRaws()
+        self.task._defineVisits()
+        self.task._defineVisits()  # must not raise
+
+        testId = {"visit": self.VISIT_ID, "instrument": self.INSTRUMENT, }
+        exposures = list(self.butler.registry.queryDimensions("exposure", dataId=testId))
+        self.assertEqual(len(exposures), 1)
+
+    def testVisitsUndefinable(self):
+        """Test that attempts to define visits with no exposures raise an exception.
+        """
+        with self.assertRaises(RuntimeError):
+            self.task._defineVisits()
+
     def testCopyConfigs(self):
         """Test that "ingesting" configs stores them in the workspace for later reference.
         """

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -330,9 +330,11 @@ class IngestionTestSuiteGen3(DataTestCase):
                           'physical_filter': 'i'},
                          ]
 
-    @staticmethod
-    def makeTestConfig():
+    @classmethod
+    def makeTestConfig(cls):
+        instrument = cls.dataset.instrument
         config = ingestion.Gen3DatasetIngestConfig()
+        instrument.applyConfigOverrides(ingestion.Gen3DatasetIngestTask._DefaultName, config)
         return config
 
     def setUp(self):


### PR DESCRIPTION
This PR adds a visit definition subtask to `Gen3DatasetIngestTask`. Calls to `ingest_dataset.py` will now create a repository with fully defined visits, as appropriate for a given instrument.