### PR TITLE
DM-21919: Run ap_verify end-to-end in Gen 3

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -63,7 +63,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
 .. option:: --dataset-metrics-config <filename>
 
-   **Input dataset-level metrics config.**
+   **Input dataset-level metrics config. (Gen 2 only)**
 
    A config file containing a `~lsst.verify.gen2tasks.MetricsControllerConfig`, which specifies which metrics are measured and sets any options.
    If this argument is omitted, :file:`config/default_dataset_metrics.py` will be used.
@@ -99,7 +99,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    
 .. option:: --image-metrics-config <filename>
 
-   **Input image-level metrics config.**
+   **Input image-level metrics config. (Gen 2 only)**
 
    A config file containing a `~lsst.verify.gen2tasks.MetricsControllerConfig`, which specifies which metrics are measured and sets any options.
    If this argument is omitted, :file:`config/default_image_metrics.py` will be used.

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -29,8 +29,10 @@ These two arguments are mandatory, all others are optional (though use of either
 Status code
 ===========
 
-Like :ref:`command-line tasks <command-line-task-argument-reference>`, :command:`ap_verify.py` returns the number of data IDs that could not be processed (i.e., 0 on a complete success).
-However, an uncaught exception causes :command:`ap_verify.py` to return an interpreter-dependent nonzero value instead (also as for command-line tasks).
+:command:`ap_verify.py` returns 0 on success, and a non-zero value if there were any processing problems.
+In :option:`--gen2` mode, the status code is the number of data IDs that could not be processed, like for :ref:`command-line tasks <command-line-task-argument-reference>`.
+
+With both :option:`--gen2` and :option:`--gen3`, an uncaught exception may cause :command:`ap_verify.py` to return an interpreter-dependent nonzero value instead of the above.
 
 .. _ap-verify-cmd-args:
 
@@ -43,8 +45,10 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
    **Butler data ID.**
 
-   Specify data ID to process using :doc:`data ID syntax </modules/lsst.pipe.base/command-line-task-dataid-howto>`.
-   For example, ``--id "visit=12345 ccd=1..6 filter=g"``.
+   Specify data ID to process.
+   If using :option:`--gen2`, this should use :doc:`data ID syntax </modules/lsst.pipe.base/command-line-task-dataid-howto>`, such as ``--id "visit=12345 ccd=1..6 filter=g"``.
+   If using :option:`--gen3`, this should use :ref:`dimension expression syntax <daf_butler_dimension_expressions>`, such as ``--id "visit=12345 and detector in (1..6) and abstract_filter='g'"``.
+
    Multiple copies of this argument are allowed.
    For compatibility with the syntax used by command line tasks, ``--id`` with no argument processes all data IDs.
 
@@ -109,7 +113,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
 .. option:: --metrics-file <filename>
 
-   **Output metrics file.**
+   **Output metrics file. (Gen 2 only)**
 
    The template for a file to contain metrics measured by ``ap_verify``, in a format readable by the :doc:`lsst.verify</modules/lsst.verify/index>` framework.
    The string ``{dataId}`` shall be replaced with the data ID associated with the job, and its use is strongly recommended.

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -73,6 +73,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    If this argument is omitted, :file:`config/default_dataset_metrics.py` will be used.
 
    Use :option:`--image-metrics-config` to configure image-level metrics instead.
+   For the Gen 3 equivalent to this option, see :option:`--pipeline`.
    See also :doc:`new-metrics`.
 
 .. option:: --gen2
@@ -109,6 +110,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    If this argument is omitted, :file:`config/default_image_metrics.py` will be used.
 
    Use :option:`--dataset-metrics-config` to configure dataset-level metrics instead.
+   For the Gen 3 equivalent to this option, see :option:`--pipeline`.
    See also :doc:`new-metrics`.
 
 .. option:: --metrics-file <filename>
@@ -127,3 +129,19 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
    The workspace will be created if it does not exist, and will contain both input and output repositories required for processing the data.
    The path may be absolute or relative to the current working directory.
+
+.. option:: -p, --pipeline <filename>
+
+   **Custom ap_verify pipeline. (Gen 3 only)**
+
+   A pipeline definition file containing a custom verification pipeline.
+   If omitted, :file:`pipelines/ApVerify.yaml` will be used.
+
+   The most common use for a custom pipeline is adding or removing metrics to be run along with the AP pipeline.
+
+   .. note::
+
+      At present, ap_verify assumes that the provided pipeline is some superset of the AP pipeline.
+      It will likely crash if any AP tasks are missing.
+
+   For the Gen 2 equivalent to this option, see :option:`--dataset-metrics-config` and :option:`--image-metrics-config`.

--- a/doc/lsst.ap.verify/failsafe.rst
+++ b/doc/lsst.ap.verify/failsafe.rst
@@ -26,12 +26,15 @@ In particular, where possible it will :ref:`preserve metrics<ap-verify-failsafe-
 Recovering metrics from partial runs
 ====================================
 
-``ap_verify`` produces some measurements even if the pipeline cannot run to completion.
+In Gen 2 mode, ``ap_verify`` produces some measurements even if the pipeline cannot run to completion.
 Specifically, if a task fails, any previously completed tasks that store measurements to disk will have done so.
 In addition, if a metric cannot be computed, ``ap_verify`` may attempt to store the values of the remaining metrics.
 
 If the pipeline fails, ``ap_verify`` may not preserve measurements computed from the dataset.
 Once the framework for handling metrics is finalized, ``ap_verify`` may be able to offer a broader guarantee that does not depend on how or where any individual metric is implemented.
+
+The Gen 3 framework is not yet mature enough to handle partial failures.
+It is expected that Gen 3 processing will eventually be able to compute all metrics from completed tasks.
 
 Further reading
 ===============

--- a/doc/lsst.ap.verify/new-metrics.rst
+++ b/doc/lsst.ap.verify/new-metrics.rst
@@ -20,8 +20,11 @@ The ``ap_verify`` package provides two config files in the :file:`config/` direc
 These files feature complex logic to minimize code duplication and minimize the work in adding new metrics.
 This complexity is not required by ``MetricsControllerTask``; a config that's just a list of assignments will also work.
 
-In Gen 3, the metrics computed by ``ap_verify`` are configured as part of the pipeline in :file:`pipelines/ApVerify.yaml`.
-To make it easy to manage, all :lsst-task:`~lsst.verify.gen2tasks.metricTask.MetricTask` configuration is done in separate sub-pipelines that are then included in :file:`ApVerify.yaml`.
+In Gen 3, the metrics computed by ``ap_verify`` are configured as part of the pipeline.
+The pipeline can be overridden using the :option:`--pipeline` command-line option.
+
+The ``ap_verify`` package provides a default-instrumented pipeline in :file:`pipelines/ApVerify.yaml`.
+To make it easy to mix and match metrics, all :lsst-task:`~lsst.verify.gen2tasks.metricTask.MetricTask` configuration is done in separate sub-pipelines that are then included in :file:`ApVerify.yaml`.
 
 Further reading
 ===============

--- a/doc/lsst.ap.verify/new-metrics.rst
+++ b/doc/lsst.ap.verify/new-metrics.rst
@@ -12,13 +12,16 @@ Configuring metrics for ap_verify
 Each metric has an associated :lsst-task:`~lsst.verify.gen2tasks.metricTask.MetricTask`, typically in the package associated with the metric.
 For example, the code for computing ``ip_diffim.numSciSources`` can be found in the ``ip_diffim`` package, not in ``ap_verify``.
 
-The metrics computed by ``ap_verify`` are configured through two command-line options, :option:`--image-metrics-config` and :option:`--dataset-metrics-config`.
+In Gen 2, the metrics computed by ``ap_verify`` are configured through two command-line options, :option:`--image-metrics-config` and :option:`--dataset-metrics-config`.
 These options each take a config file for a `~lsst.verify.gen2tasks.metricsControllerTask.MetricsControllerConfig`, the former for metrics that are computed over individual images and the latter for metrics that apply to the entire dataset.
 Typically, a file configures each metric through ``config.measurers[<name>]``; see the documentation for :lsst-task:`~lsst.verify.gen2tasks.MetricsControllerTask` for examples.
 
 The ``ap_verify`` package provides two config files in the :file:`config/` directory, which define the image- and dataset-level configs that are run by default (for example, during CI).
 These files feature complex logic to minimize code duplication and minimize the work in adding new metrics.
 This complexity is not required by ``MetricsControllerTask``; a config that's just a list of assignments will also work.
+
+In Gen 3, the metrics computed by ``ap_verify`` are configured as part of the pipeline in :file:`pipelines/ApVerify.yaml`.
+To make it easy to manage, all :lsst-task:`~lsst.verify.gen2tasks.metricTask.MetricTask` configuration is done in separate sub-pipelines that are then included in :file:`ApVerify.yaml`.
 
 Further reading
 ===============

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -26,8 +26,8 @@ The dataset names are a placeholder for a future data repository versioning syst
 
 .. _ap-verify-run-output:
 
-How to run ap_verify in a new workspace
-=======================================
+How to run ap_verify in a new workspace (Gen 2 pipeline)
+========================================================
 
 Using the `HiTS 2015 <https://github.com/lsst/ap_verify_hits2015/>`_ dataset as an example, one can run :command:`ap_verify.py` as follows:
 
@@ -45,9 +45,9 @@ while the output is:
 
 * :command:`workspaces/hits/` is the location where the pipeline will create any :ref:`Butler repositories<command-line-task-data-repo-using-uris>` necessary,
 
-This call will create a new directory at :file:`workspaces/hits`, ingest the HiTS data into a new repository based on :file:`<hits-data>/repo/`, then run visit 412518 through the entire AP pipeline.
+This call will create a new directory at :file:`workspaces/hits`, ingest the HiTS data into a new repository based on :file:`<hits-data>/repo/`, then run visits 412518 and 412568 through the entire AP pipeline.
 
-It's also possible to run an entire dataset by omitting the :command:`--id` argument (as some datasets are very large, do this with caution):
+It's also possible to run an entire dataset by omitting the :option:`--id` argument (as some datasets are very large, do this with caution):
 
 .. prompt:: bash
 
@@ -57,6 +57,25 @@ It's also possible to run an entire dataset by omitting the :command:`--id` argu
 
    The command-line interface for :command:`ap_verify.py` is at present more limited than those of command-line tasks.
    See the :doc:`command-line-reference` for details.
+
+.. _ap-verify-run-output-gen3:
+
+How to run ap_verify in a new workspace (Gen 3 pipeline)
+========================================================
+
+The command for running the pipeline on Gen 3 data is almost identical to Gen 2:
+
+.. prompt:: bash
+
+   ap_verify.py --dataset HiTS2015 --gen3 --id "visit in (412518, 412568) and abstract_filter='g'" --output workspaces/hits/
+
+The only differences are substituting :option:`--gen3` for :option:`--gen2`, and formatting the (optional) data ID in the :ref:`Gen 3 query syntax <daf_butler_dimension_expressions>`.
+
+.. note::
+
+   Because the science pipelines are still being converted to Gen 3, Gen 3 processing may not be supported for all ap_verify datasets.
+   See the individual dataset's documentation for more details.
+
 
 .. _ap-verify-run-ingest:
 
@@ -78,8 +97,8 @@ Other options from :command:`ap_verify.py` are not available.
 
 .. _ap-verify-results:
 
-How to use measurements of metrics
-==================================
+How to use measurements of metrics (Gen 2 pipeline)
+===================================================
 
 After ``ap_verify`` has run, it will produce files named, by default, :file:`ap_verify.<dataId>.verify.json` in the caller's directory.
 The file name may be customized using the :option:`--metrics-file` command-line argument.
@@ -87,6 +106,19 @@ These files contain metric measurements in ``lsst.verify`` format, and can be lo
 
 If the pipeline is interrupted by a fatal error, completed measurements will be saved to metrics files for debugging purposes.
 See the :ref:`error-handling policy <ap-verify-failsafe-partialmetric>` for details.
+
+.. _ap-verify-results-gen3:
+
+How to use measurements of metrics (Gen 3 pipeline)
+===================================================
+
+After ``ap_verify`` has run, it will produce Butler datasets named ``metricValue_<metric package>_<metric>``.
+These can be queried, like any Butler dataset, using methods like `~lsst.daf.butler.Registry.queryDatasetTypes` and `~lsst.daf.butler.Butler.get`.
+
+.. note::
+
+   Not all metric values need have the same data ID as the data run through the pipeline.
+   For example, metrics describing the full focal plane have a visit but no detector.
 
 Further reading
 ===============

--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -1,0 +1,19 @@
+# Gen 3 pipeline for ap_verify
+# This concatenates various lsst.verify metrics to an AP pipeline
+
+description: Fully instrumented AP pipeline
+inherits:
+    - location: $AP_PIPE_DIR/pipelines/ApPipe.yaml
+    - location: $AP_VERIFY_DIR/pipelines/MetricsRuntime.yaml
+    - location: $AP_VERIFY_DIR/pipelines/MetricsMisc.yaml
+tasks:
+    diaPipe:
+        # TODO: how to prevent duplication with ApPipe definition?
+        class: lsst.ap.association.DiaPipelineTask
+        config:
+            apdb.isolation_level: READ_UNCOMMITTED
+            doPackageAlerts: True
+contracts:
+    # Metric inputs must match pipeline outputs
+    - imageDifference.connections.coaddName == fracDiaSourcesToSciSources.connections.coaddName
+    - imageDifference.connections.fakesType == fracDiaSourcesToSciSources.connections.fakesType

--- a/pipelines/MetricsMisc.yaml
+++ b/pipelines/MetricsMisc.yaml
@@ -1,0 +1,24 @@
+# Miscellaneous metrics for Alert Production
+# In the future, these might be placed in task-specific pipelines (for debugging)
+# or grouped by their datasets (to optimize expensive Butler reads)
+
+description: Miscelaneous AP Pipeline metrics
+tasks:
+    numNewDiaObjects:
+        class: lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask
+        config:
+            connections.labelName: diaPipe  # partial name of metadata dataset
+    numUnassociatedDiaObjects:
+        class: lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask
+        config:
+            connections.labelName: diaPipe
+    fracUpdatedDiaObjects:
+        class: lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask
+        config:
+            connections.labelName: diaPipe
+    totalUnassociatedDiaObjects:
+        class: lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask
+    numSciSources:
+        class: lsst.ip.diffim.metrics.NumberSciSourcesMetricTask
+    fracDiaSourcesToSciSources:
+        class: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask

--- a/pipelines/MetricsRuntime.yaml
+++ b/pipelines/MetricsRuntime.yaml
@@ -1,0 +1,88 @@
+# Timing and system resource metrics for Alert Production
+
+description: Runtime metrics (customized for AP pipeline)
+tasks:
+    timing_isr:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: ip_isr  # metrics package
+            connections.metric: IsrTime  # metric name
+            connections.labelName: isr   # partial name of metadata dataset
+            metadataDimensions: [instrument, exposure, detector]  # TimingMetricTask assumes visit
+            target: isr.run              # method name in metadata. Usually matches label for top-level tasks
+    timing_charImage:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: pipe_tasks
+            connections.metric: CharacterizeImageTime
+            connections.labelName: charImage
+            target: characterizeImage.run
+    timing_calibrate:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: pipe_tasks
+            connections.metric: CalibrateTime
+            connections.labelName: calibrate
+            target: calibrate.run
+    timing_imageDifference:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: pipe_tasks
+            connections.metric: ImageDifferenceTime
+            connections.labelName: imageDifference
+            metadataDimensions: [instrument, visit, detector, skymap]
+            target: imageDifference.run
+    timing_imageDifference_astrometer:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: meas_astrom
+            connections.metric: AstrometryTime
+            connections.labelName: imageDifference
+            metadataDimensions: [instrument, visit, detector, skymap]
+            target: imageDifference:astrometer.loadAndMatch
+    timing_imageDifference_register:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: pipe_tasks
+            connections.metric: RegisterImageTime
+            connections.labelName: imageDifference
+            metadataDimensions: [instrument, visit, detector, skymap]
+            target: imageDifference:register.run
+    timing_imageDifference_subtract:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: ip_diffim
+            connections.metric: ImagePsfMatchTime
+            connections.labelName: imageDifference
+            metadataDimensions: [instrument, visit, detector, skymap]
+            target: imageDifference:subtract.subtractExposures
+    timing_imageDifference_detection:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: meas_algorithms
+            connections.metric: SourceDetectionTime
+            connections.labelName: imageDifference
+            metadataDimensions: [instrument, visit, detector, skymap]
+            target: imageDifference:detection.run
+    timing_imageDifference_measurement:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: ip_diffim
+            connections.metric: DipoleFitTime
+            connections.labelName: imageDifference
+            metadataDimensions: [instrument, visit, detector, skymap]
+            target: imageDifference:measurement.run
+    timing_diaPipe_associator:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: ap_association
+            connections.metric: AssociationTime
+            connections.labelName: diaPipe
+            target: diaPipe:associator.run
+    memory_apPipe:
+        class: lsst.verify.tasks.commonMetrics.MemoryMetricTask
+        config:
+            connections.package: ap_pipe
+            connections.metric: ApPipeMemory
+            connections.labelName: diaPipe
+            target: diaPipe.run  # Memory use is peak over process, so measure last task

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -37,7 +37,7 @@ import lsst.log
 from .dataset import Dataset
 from .ingestion import ingestDataset, ingestDatasetGen3
 from .metrics import MetricsParser, computeMetrics
-from .pipeline_driver import ApPipeParser, runApPipeGen2
+from .pipeline_driver import ApPipeParser, runApPipeGen2, runApPipeGen3
 from .workspace import WorkspaceGen2, WorkspaceGen3
 
 
@@ -162,14 +162,19 @@ def runApVerify(cmdLine=None):
     args = _ApVerifyParser().parse_args(args=cmdLine)
     log.debug('Command-line arguments: %s', args)
 
-    workspace = WorkspaceGen2(args.output)
-    ingestDataset(args.dataset, workspace)
-
-    log.info('Running pipeline...')
-    apPipeResults = runApPipeGen2(workspace, args)
-    computeMetrics(workspace, apPipeResults.parsedCmd.id, args)
-
-    return _getCmdLineExitStatus(apPipeResults.resultList)
+    if args.useGen3:
+        workspace = WorkspaceGen3(args.output)
+        ingestDatasetGen3(args.dataset, workspace)
+        log.info('Running pipeline...')
+        # Gen 3 pipeline includes both AP and metrics
+        return runApPipeGen3(workspace, args)
+    else:
+        workspace = WorkspaceGen2(args.output)
+        ingestDataset(args.dataset, workspace)
+        log.info('Running pipeline...')
+        apPipeResults = runApPipeGen2(workspace, args)
+        computeMetrics(workspace, apPipeResults.parsedCmd.id, args)
+        return _getCmdLineExitStatus(apPipeResults.resultList)
 
 
 def _getCmdLineExitStatus(resultList):

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -37,7 +37,7 @@ import lsst.log
 from .dataset import Dataset
 from .ingestion import ingestDataset, ingestDatasetGen3
 from .metrics import MetricsParser, computeMetrics
-from .pipeline_driver import ApPipeParser, runApPipe
+from .pipeline_driver import ApPipeParser, runApPipeGen2
 from .workspace import WorkspaceGen2, WorkspaceGen3
 
 
@@ -166,7 +166,7 @@ def runApVerify(cmdLine=None):
     ingestDataset(args.dataset, workspace)
 
     log.info('Running pipeline...')
-    apPipeResults = runApPipe(workspace, args)
+    apPipeResults = runApPipeGen2(workspace, args)
     computeMetrics(workspace, apPipeResults.parsedCmd.id, args)
 
     return _getCmdLineExitStatus(apPipeResults.resultList)

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -49,12 +49,16 @@ class ApPipeParser(argparse.ArgumentParser):
     """
 
     def __init__(self):
+        defaultPipeline = os.path.join(getPackageDir("ap_verify"), "pipelines", "ApVerify.yaml")
+
         # Help and documentation will be handled by main program's parser
         argparse.ArgumentParser.__init__(self, add_help=False)
         # namespace.dataIds will always be a list of 0 or more nonempty strings, regardless of inputs.
         # TODO: in Python 3.8+, action='extend' handles nargs='?' more naturally than 'append'.
         self.add_argument('--id', dest='dataIds', action=self.AppendOptional, nargs='?', default=[],
                           help='An identifier for the data to process.')
+        self.add_argument("-p", "--pipeline", default=defaultPipeline,
+                          help="A custom version of the ap_verify pipeline (e.g., with different metrics).")
         self.add_argument("-j", "--processes", default=1, type=int,
                           help="Number of processes to use.")
         self.add_argument("--skip-pipeline", action="store_true",
@@ -143,11 +147,9 @@ def runApPipeGen3(workspace, parsedCmdLine):
     # Currently makeApdb has different argument conventions from Gen 3; see DM-22663
     makeApdb(_getConfigArguments(workspace))
 
-    # TODO: add user override for this
-    pipelineFile = os.path.join(getPackageDir("ap_verify"), "pipelines", "ApVerify.yaml")
     pipelineArgs = ["run",
                     "--butler-config", workspace.repo,
-                    "--pipeline", pipelineFile,
+                    "--pipeline", parsedCmdLine.pipeline,
                     ]
     # TODO: collections should be determined exclusively by Workspace.workButler,
     # but I can't find a way to hook that up to the graph builder. So use the CLI

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -27,13 +27,16 @@ This module handles calling `ap_pipe` and converting any information
 as needed.
 """
 
-__all__ = ["ApPipeParser", "runApPipeGen2"]
+__all__ = ["ApPipeParser", "runApPipeGen2", "runApPipeGen3"]
 
 import argparse
 import os
 
 import lsst.log
+from lsst.utils import getPackageDir
+import lsst.daf.butler as dafButler
 import lsst.pipe.base as pipeBase
+import lsst.ctrl.mpexec as ctrlMpexec
 import lsst.ap.pipe as apPipe
 from lsst.ap.pipe.make_apdb import makeApdb
 
@@ -125,13 +128,57 @@ def runApPipeGen2(workspace, parsedCmdLine):
     return results
 
 
+def runApPipeGen3(workspace, parsedCmdLine):
+    """Run `ap_pipe` on this object's dataset.
+
+    Parameters
+    ----------
+    workspace : `lsst.ap.verify.workspace.WorkspaceGen3`
+        The abstract location containing input and output repositories.
+    parsedCmdLine : `argparse.Namespace`
+        Command-line arguments, including all arguments supported by `ApPipeParser`.
+    """
+    log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipeGen3')
+
+    # Currently makeApdb has different argument conventions from Gen 3; see DM-22663
+    makeApdb(_getConfigArguments(workspace))
+
+    # TODO: add user override for this
+    pipelineFile = os.path.join(getPackageDir("ap_verify"), "pipelines", "ApVerify.yaml")
+    pipelineArgs = ["run",
+                    "--butler-config", workspace.repo,
+                    "--pipeline", pipelineFile,
+                    ]
+    # TODO: collections should be determined exclusively by Workspace.workButler,
+    # but I can't find a way to hook that up to the graph builder. So use the CLI
+    # for now and revisit once DM-26239 is done.
+    pipelineArgs.extend(_getCollectionArguments(workspace))
+    pipelineArgs.extend(_getConfigArgumentsGen3(workspace))
+    if parsedCmdLine.dataIds:
+        for singleId in parsedCmdLine.dataIds:
+            pipelineArgs.extend(["--data-query", *singleId.split(" ")])
+    pipelineArgs.extend(["--processes", str(parsedCmdLine.processes)])
+    pipelineArgs.extend(["--register-dataset-types"])
+
+    if not parsedCmdLine.skip_pipeline:
+        # TODO: generalize this code in DM-26028
+        activator = ctrlMpexec.CmdLineFwk()
+        # TODO: work off of workspace.workButler after DM-26239
+        results = activator.parseAndRun(pipelineArgs)
+
+        log.info('Pipeline complete.')
+        return results
+    else:
+        log.info('Skipping AP pipeline entirely.')
+
+
 def _getConfigArguments(workspace):
     """Return the config options for running ApPipeTask on this workspace, as
     command-line arguments.
 
     Parameters
     ----------
-    workspace : `lsst.ap.verify.workspace.Workspace`
+    workspace : `lsst.ap.verify.workspace.WorkspaceGen2`
         A Workspace whose config directory may contain an
         `~lsst.ap.pipe.ApPipeTask` config.
 
@@ -153,3 +200,61 @@ def _getConfigArguments(workspace):
     args.extend(["--config", "diaPipe.doPackageAlerts=True"])
 
     return args
+
+
+def _getConfigArgumentsGen3(workspace):
+    """Return the config options for running the Gen 3 AP Pipeline on this
+    workspace, as command-line arguments.
+
+    Parameters
+    ----------
+    workspace : `lsst.ap.verify.workspace.WorkspaceGen3`
+        A Workspace whose config directory may contain various configs.
+
+    Returns
+    -------
+    args : `list` of `str`
+        Command-line arguments calling ``--config`` or ``--configFile``,
+        following the conventions of `sys.argv`.
+    """
+    args = [
+        # ApVerify will use the sqlite hooks for the Apdb.
+        "--config", "diaPipe:apdb.db_url=sqlite:///" + workspace.dbLocation,
+        "--config", "diaPipe:apdb.isolation_level=READ_UNCOMMITTED",
+        # Put output alerts into the workspace.
+        "--config", "diaPipe:alertPackager.alertWriteLocation=" + workspace.alertLocation,
+        "--config", "diaPipe:doPackageAlerts=True",
+        # TODO: the configs below should not be needed after DM-26140
+        "--configfile", "calibrate:" + os.path.join(workspace.configDir, "calibrate.py"),
+        "--configfile", "imageDifference:" + os.path.join(workspace.configDir, "imageDifference.py"),
+    ]
+    # TODO: reverse-engineering the instrument should not be needed after DM-26140
+    # pipetask will crash if there is more than one instrument
+    for idRecord in workspace.workButler.registry.queryDataIds("instrument").expanded():
+        className = idRecord.records["instrument"].class_name
+        args.extend(["--instrument", className])
+
+    return args
+
+
+def _getCollectionArguments(workspace):
+    """Return the collections for running the Gen 3 AP Pipeline on this
+    workspace, as command-line arguments.
+
+    Parameters
+    ----------
+    workspace : `lsst.ap.verify.workspace.WorkspaceGen3`
+        A Workspace with a Gen 3 repository.
+
+    Returns
+    -------
+    args : `list` of `str`
+        Command-line arguments calling ``--input`` or ``--output``,
+        following the conventions of `sys.argv`.
+    """
+    butler = workspace.workButler
+    inputs = set(butler.registry.queryCollections(collectionType=dafButler.CollectionType.RUN))
+    inputs.discard(workspace.runName)
+    return ["--input", ",".join(inputs),
+            "--output-run", workspace.runName, "--extend-run",
+            ]

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -156,7 +156,7 @@ def runApPipeGen3(workspace, parsedCmdLine):
     pipelineArgs.extend(_getConfigArgumentsGen3(workspace))
     if parsedCmdLine.dataIds:
         for singleId in parsedCmdLine.dataIds:
-            pipelineArgs.extend(["--data-query", *singleId.split(" ")])
+            pipelineArgs.extend(["--data-query", singleId])
     pipelineArgs.extend(["--processes", str(parsedCmdLine.processes)])
     pipelineArgs.extend(["--register-dataset-types"])
 
@@ -256,5 +256,5 @@ def _getCollectionArguments(workspace):
     inputs = set(butler.registry.queryCollections(collectionType=dafButler.CollectionType.RUN))
     inputs.discard(workspace.runName)
     return ["--input", ",".join(inputs),
-            "--output-run", workspace.runName, "--extend-run",
+            "--output-run", workspace.runName,
             ]

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -27,7 +27,7 @@ This module handles calling `ap_pipe` and converting any information
 as needed.
 """
 
-__all__ = ["ApPipeParser", "runApPipe"]
+__all__ = ["ApPipeParser", "runApPipeGen2"]
 
 import argparse
 import os
@@ -73,7 +73,7 @@ class ApPipeParser(argparse.ArgumentParser):
                     setattr(namespace, self.dest, [values])
 
 
-def runApPipe(workspace, parsedCmdLine):
+def runApPipeGen2(workspace, parsedCmdLine):
     """Run `ap_pipe` on this object's dataset.
 
     Parameters
@@ -90,7 +90,7 @@ def runApPipe(workspace, parsedCmdLine):
         ``doReturnResults=False``. This object is valid even if
         `~lsst.ap.pipe.ApPipeTask` was never run.
     """
-    log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipe')
+    log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipeGen2')
 
     configArgs = _getConfigArguments(workspace)
     makeApdb(configArgs)

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -149,7 +149,7 @@ def _getConfigArguments(workspace):
     args.extend(["--config", "diaPipe.apdb.db_url=sqlite:///" + workspace.dbLocation])
     args.extend(["--config", "diaPipe.apdb.isolation_level=READ_UNCOMMITTED"])
     # Put output alerts into the workspace.
-    args.extend(["--config", "diaPipe.alertPackager.alertWriteLocation=" + workspace.workDir + "/alerts"])
+    args.extend(["--config", "diaPipe.alertPackager.alertWriteLocation=" + workspace.alertLocation])
     args.extend(["--config", "diaPipe.doPackageAlerts=True"])
 
     return args

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -300,7 +300,8 @@ class WorkspaceGen3(Workspace):
                     instrument = obsBase.Instrument.fromName(dimension["instrument"], queryButler.registry)
                     inputs.add(instrument.makeDefaultRawIngestRunName())
 
-                self._workButler = dafButler.Butler(butler=queryButler, collections=inputs, run=self.runName)
+                # should set run=self.runName, but this breaks quantum graph generation (DM-26246)
+                self._workButler = dafButler.Butler(butler=queryButler, collections=inputs)
             except OSError as e:
                 raise RuntimeError(f"{self.repo} is not a Gen 3 repository") from e
         return self._workButler

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -103,6 +103,13 @@ class Workspace(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
+    def alertLocation(self):
+        """The absolute location of an output directory for persisted
+        alert packets (`str`, read-only).
+        """
+
+    @property
+    @abc.abstractmethod
     def workButler(self):
         """A Butler that can produce pipeline inputs and outputs (read-only).
         The type is class-dependent.
@@ -181,6 +188,10 @@ class WorkspaceGen2(Workspace):
     @property
     def dbLocation(self):
         return os.path.join(self._location, 'association.db')
+
+    @property
+    def alertLocation(self):
+        return os.path.join(self._location, 'alerts')
 
     @property
     def workButler(self):
@@ -266,6 +277,10 @@ class WorkspaceGen3(Workspace):
     @property
     def dbLocation(self):
         return os.path.join(self._location, 'association.db')
+
+    @property
+    def alertLocation(self):
+        return os.path.join(self._location, 'alerts')
 
     @property
     def workButler(self):

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -63,7 +63,7 @@ def patchApPipe(method):
     return wrapper
 
 
-class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
+class PipelineDriverTestSuiteGen2(lsst.utils.tests.TestCase):
     def setUp(self):
         self._testDir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self._testDir, ignore_errors=True)
@@ -111,19 +111,19 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
 
     # Mock up ApPipeTask to avoid doing any processing.
     @patchApPipe
-    def testRunApPipeSteps(self, mockDb, mockClass):
-        """Test that runApPipe runs the entire pipeline.
+    def testrunApPipeGen2Steps(self, mockDb, mockClass):
+        """Test that runApPipeGen2 runs the entire pipeline.
         """
-        pipeline_driver.runApPipe(self.workspace, self.apPipeArgs)
+        pipeline_driver.runApPipeGen2(self.workspace, self.apPipeArgs)
 
         mockDb.assert_called_once()
         mockClass.parseAndRun.assert_called_once()
 
     @patchApPipe
-    def testRunApPipeDataIdReporting(self, _mockDb, _mockClass):
-        """Test that runApPipe reports the data IDs that were processed.
+    def testrunApPipeGen2DataIdReporting(self, _mockDb, _mockClass):
+        """Test that runApPipeGen2 reports the data IDs that were processed.
         """
-        results = pipeline_driver.runApPipe(self.workspace, self.apPipeArgs)
+        results = pipeline_driver.runApPipeGen2(self.workspace, self.apPipeArgs)
         ids = results.parsedCmd.id
 
         self.assertEqual(ids.idList, _getDataIds())
@@ -137,21 +137,21 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
             self.fail("No command-line args passed to parseAndRun!")
 
     @patchApPipe
-    def testRunApPipeCustomConfig(self, _mockDb, mockClass):
-        """Test that runApPipe can pass custom configs from a workspace to ApPipeTask.
+    def testrunApPipeGen2CustomConfig(self, _mockDb, mockClass):
+        """Test that runApPipeGen2 can pass custom configs from a workspace to ApPipeTask.
         """
         mockParse = mockClass.parseAndRun
-        pipeline_driver.runApPipe(self.workspace, self.apPipeArgs)
+        pipeline_driver.runApPipeGen2(self.workspace, self.apPipeArgs)
         mockParse.assert_called_once()
         cmdLineArgs = self._getCmdLineArgs(mockParse.call_args)
         self.assertIn(os.path.join(self.workspace.configDir, "apPipe.py"), cmdLineArgs)
 
     @patchApPipe
-    def testRunApPipeWorkspaceDb(self, mockDb, mockClass):
-        """Test that runApPipe places a database in the workspace location by default.
+    def testrunApPipeGen2WorkspaceDb(self, mockDb, mockClass):
+        """Test that runApPipeGen2 places a database in the workspace location by default.
         """
         mockParse = mockClass.parseAndRun
-        pipeline_driver.runApPipe(self.workspace, self.apPipeArgs)
+        pipeline_driver.runApPipeGen2(self.workspace, self.apPipeArgs)
 
         mockDb.assert_called_once()
         cmdLineArgs = self._getCmdLineArgs(mockDb.call_args)
@@ -162,13 +162,13 @@ class PipelineDriverTestSuite(lsst.utils.tests.TestCase):
         self.assertIn("diaPipe.apdb.db_url=sqlite:///" + self.workspace.dbLocation, cmdLineArgs)
 
     @patchApPipe
-    def testRunApPipeReuse(self, _mockDb, mockClass):
-        """Test that runApPipe does not run the pipeline at all (not even with
+    def testrunApPipeGen2Reuse(self, _mockDb, mockClass):
+        """Test that runApPipeGen2 does not run the pipeline at all (not even with
         --reuse-outputs-from) if --skip-pipeline is provided.
         """
         mockParse = mockClass.parseAndRun
         skipArgs = pipeline_driver.ApPipeParser().parse_args(["--skip-pipeline"])
-        pipeline_driver.runApPipe(self.workspace, skipArgs)
+        pipeline_driver.runApPipeGen2(self.workspace, skipArgs)
         mockParse.assert_not_called()
 
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -102,6 +102,16 @@ class WorkspaceGen2TestSuite(lsst.utils.tests.TestCase):
             # Workspace spec allows these to be URIs or paths, whatever the Butler accepts
             self._assertNotInDir(self._testbed.dbLocation, url2pathname(repo))
 
+    def testAlerts(self):
+        """Verify that a WorkspaceGen2 requests an alert dump in the target
+        directory, but not in any repository.
+        """
+        root = self._testWorkspace
+        self._assertInDir(self._testbed.alertLocation, root)
+        for repo in self._allRepos(self._testbed):
+            # Workspace spec allows these to be URIs or paths, whatever the Butler accepts
+            self._assertNotInDir(self._testbed.alertLocation, url2pathname(repo))
+
 
 class WorkspaceGen3TestSuite(lsst.utils.tests.TestCase):
 
@@ -161,6 +171,15 @@ class WorkspaceGen3TestSuite(lsst.utils.tests.TestCase):
         self._assertInDir(self._testbed.dbLocation, root)
         # Workspace spec allows these to be URIs or paths, whatever the Butler accepts
         self._assertNotInDir(self._testbed.dbLocation, url2pathname(self._testbed.repo))
+
+    def testAlerts(self):
+        """Verify that a WorkspaceGen3 requests an alert dump in the target
+        directory, but not in any repository.
+        """
+        root = self._testWorkspace
+        self._assertInDir(self._testbed.alertLocation, root)
+        # Workspace spec allows these to be URIs or paths, whatever the Butler accepts
+        self._assertNotInDir(self._testbed.alertLocation, url2pathname(self._testbed.repo))
 
     def testWorkButler(self):
         """Verify that the Gen 3 Butler is available if and only if the repository is set up.

--- a/ups/ap_verify.table
+++ b/ups/ap_verify.table
@@ -5,6 +5,7 @@ setupRequired(daf_persistence)
 setupRequired(pipe_tasks)
 setupRequired(verify)
 setupRequired(ap_pipe)
+setupRequired(ctrl_mpexec)
 
 # For testing
 setupOptional(ap_verify_testdata)


### PR DESCRIPTION
This PR implements the ability to run `ap_verify` entirely in Gen 3. This is a preliminary implementation designed to get something working in CI; see [Jira](https://jira.lsstcorp.org/browse/DM-21919) for a list of ticketed improvements.

This PR is relative to `tickets/DM-26070` to make it easy to see what is changing on this ticket; it must not be merged to `master` before #96.