### PR TITLE
DM-26040: Add AP timing metrics for DiaPipelineTask and all subtasks

### DIFF
--- a/config/default_image_metrics.py
+++ b/config/default_image_metrics.py
@@ -23,10 +23,17 @@ timingConfigs = {
     "apPipe:differencer:subtract.subtractExposures": "ip_diffim.ImagePsfMatchTime",
     "apPipe:differencer:detection.run": "meas_algorithms.SourceDetectionTime",
     "apPipe:differencer:measurement.run": "ip_diffim.DipoleFitTime",
+    "apPipe:diaPipe.run": "ap_association.DiaPipelineTime",
+    "apPipe:diaPipe:diaSourceDpddifier.run": "ap_association.MapDiaSourceTime",
+    "apPipe:diaPipe:diaCatalogLoader.run": "ap_association.LoadDiaCatalogsTime",
     "apPipe:diaPipe:associator.run": "ap_association.AssociationTime",
+    "apPipe:diaPipe:diaForcedSource.run": "ap_association.DiaForcedSourceTime",
+    "apPipe:diaPipe:alertPackager.run": "ap_association.PackageAlertsTime",
 }
 memoryConfigs = {
     "apPipe.runDataRef": "ap_pipe.ApPipeMemory",
+    "apPipe:diaPipe:diaForcedSource.run": "ap_association.DiaForcedSourceMemory",
+    "apPipe:diaPipe:alertPackager.run": "ap_association.PackageAlertsMemory",
 }
 for target, metric in timingConfigs.items():
     subConfig = TimingMetricConfig()

--- a/pipelines/MetricsRuntime.yaml
+++ b/pipelines/MetricsRuntime.yaml
@@ -72,6 +72,27 @@ tasks:
             connections.labelName: imageDifference
             metadataDimensions: [instrument, visit, detector, skymap]
             target: imageDifference:measurement.run
+    timing_diaPipe:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: ap_association
+            connections.metric: DiaPipelineTime
+            connections.labelName: diaPipe
+            target: diaPipe.run
+    timing_diaPipe_diaSourceDpddifier:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: ap_association
+            connections.metric: MapDiaSourceTime
+            connections.labelName: diaPipe
+            target: diaPipe:diaSourceDpddifier.run
+    timing_diaPipe_diaCatalogLoader:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: ap_association
+            connections.metric: LoadDiaCatalogsTime
+            connections.labelName: diaPipe
+            target: diaPipe:diaCatalogLoader.run
     timing_diaPipe_associator:
         class: lsst.verify.tasks.commonMetrics.TimingMetricTask
         config:
@@ -79,6 +100,20 @@ tasks:
             connections.metric: AssociationTime
             connections.labelName: diaPipe
             target: diaPipe:associator.run
+    timing_diaPipe_diaForcedSource:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: ap_association
+            connections.metric: DiaForcedSourceTime
+            connections.labelName: diaPipe
+            target: diaPipe:diaForcedSource.run
+    timing_diaPipe_alertPackager:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.package: ap_association
+            connections.metric: PackageAlertsTime
+            connections.labelName: diaPipe
+            target: diaPipe:alertPackager.run
     memory_apPipe:
         class: lsst.verify.tasks.commonMetrics.MemoryMetricTask
         config:
@@ -86,3 +121,17 @@ tasks:
             connections.metric: ApPipeMemory
             connections.labelName: diaPipe
             target: diaPipe.run  # Memory use is peak over process, so measure last task
+    memory_diaForcedSource:
+        class: lsst.verify.tasks.commonMetrics.MemoryMetricTask
+        config:
+            connections.package: ap_association
+            connections.metric: DiaForcedSourceMemory
+            connections.labelName: diaPipe
+            target: diaPipe:diaForcedSource.run
+    memory_alertPackager:
+        class: lsst.verify.tasks.commonMetrics.MemoryMetricTask
+        config:
+            connections.package: ap_association
+            connections.metric: PackageAlertsMemory
+            connections.labelName: diaPipe
+            target: diaPipe:alertPackager.run


### PR DESCRIPTION
This PR adds the timing metrics created in lsst/verify_metrics#24 to both the Gen 2 and Gen 3 defaults for `ap_verify`.