### PR TITLE
DM-26237: Can't rerun ap_verify on same repository in Gen 3

### DIFF
--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -255,18 +255,21 @@ class Dataset:
     def makeCompatibleRepoGen3(self, repoDir):
         """Set up a directory as a Gen 3 repository compatible with this ap_verify dataset.
 
-        If the directory already exists, any files required by the dataset will
-        be added if absent; otherwise the directory will remain unchanged.
+        If the repository already exists, this call has no effect.
 
         Parameters
         ----------
         repoDir : `str`
             The directory where the output repository will be created.
         """
-        repoConfig = dafButler.Butler.makeRepo(repoDir, overwrite=True)
-        butler = dafButler.Butler(repoConfig, writeable=True)
-        butler.import_(directory=self._preloadedRepo, filename=self._preloadedExport,
-                       transfer="auto")
+        # No way to tell makeRepo "create only what's missing"
+        try:
+            repoConfig = dafButler.Butler.makeRepo(repoDir)
+            butler = dafButler.Butler(repoConfig, writeable=True)
+            butler.import_(directory=self._preloadedRepo, filename=self._preloadedExport,
+                           transfer="auto")
+        except FileExistsError:
+            pass
 
 
 def _isRepo(repoDir):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -115,6 +115,20 @@ class DatasetTestSuite(DataTestCase):
             if os.path.exists(testDir):
                 shutil.rmtree(testDir, ignore_errors=True)
 
+    def _checkOutputGen3(self, repo):
+        """Perform various integrity checks on a repository.
+
+        Parameters
+        ----------
+        repo : `str`
+            The repository to test. Currently only filesystem repositories
+            are supported.
+        """
+        self.assertTrue(os.path.exists(repo), 'Output directory must exist.')
+        # Call to Butler will fail if repo is corrupted
+        butler = dafButler.Butler(repo)
+        self.assertIn("LSST-ImSim/calib", butler.registry.queryCollections())
+
     def testOutputGen3(self):
         """Verify that a Dataset can create an output repository as desired.
         """
@@ -123,12 +137,7 @@ class DatasetTestSuite(DataTestCase):
 
         try:
             self._testbed.makeCompatibleRepoGen3(outputDir)
-            self.assertTrue(os.path.exists(outputDir), 'Output directory must exist.')
-            self.assertTrue(os.listdir(outputDir), 'Output directory must not be empty.')
-            self.assertTrue(os.path.exists(os.path.join(outputDir, 'butler.yaml')),
-                            'Output directory must have a butler.yaml file.')
-            butler = dafButler.Butler(outputDir)
-            self.assertIn("LSST-ImSim/calib", butler.registry.queryCollections())
+            self._checkOutputGen3(outputDir)
         finally:
             if os.path.exists(testDir):
                 shutil.rmtree(testDir, ignore_errors=True)
@@ -141,18 +150,10 @@ class DatasetTestSuite(DataTestCase):
         outputDir = os.path.join(testDir, 'badOut')
 
         try:
-            os.makedirs(outputDir)
-            output = os.path.join(outputDir, 'foo.txt')
-            with open(output, 'w') as dummy:
-                dummy.write('This is a test!')
-
             self._testbed.makeCompatibleRepoGen3(outputDir)
-            self.assertTrue(os.path.exists(outputDir), 'Output directory must exist.')
-            self.assertTrue(os.listdir(outputDir), 'Output directory must not be empty.')
-            self.assertTrue(os.path.exists(os.path.join(outputDir, 'butler.yaml')),
-                            'Output directory must have a butler.yaml file.')
-            butler = dafButler.Butler(outputDir)
-            self.assertIn("LSST-ImSim/calib", butler.registry.queryCollections())
+            self._checkOutputGen3(outputDir)
+            self._testbed.makeCompatibleRepoGen3(outputDir)
+            self._checkOutputGen3(outputDir)
         finally:
             if os.path.exists(testDir):
                 shutil.rmtree(testDir, ignore_errors=True)


### PR DESCRIPTION
This PR fixes a bug in how the `ap_verify` dataset is turned into a workspace repository in Gen 3, and fixes the test case that was supposed to enforce the desired behavior.