### PR TITLE
DM-25806: Support parallel ap_verify ingestion in Gen 3

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -101,6 +101,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    **Number of processes to use.**
 
    When ``processes`` is larger than 1 the pipeline may use the Python `multiprocessing` module to parallelize processing of multiple datasets across multiple processors.
+   In Gen 3 mode, data ingestion may also be parallelized.
    
 .. option:: --image-metrics-config <filename>
 

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -92,7 +92,7 @@ Using the `HiTS 2015 <https://github.com/lsst/ap_verify_hits2015/>`_ dataset as 
 
    ingest_dataset.py --dataset HiTS2015 --gen2 --output workspaces/hits/
 
-The :option:`--dataset`, :option:`--output`, :option:`--gen2`, and :option:`--gen3` arguments behave the same way as for :command:`ap_verify.py`.
+The :option:`--dataset`, :option:`--output`, :option:`--gen2`, :option:`--gen3`, and :option:`--processes` arguments behave the same way as for :command:`ap_verify.py`.
 Other options from :command:`ap_verify.py` are not available.
 
 .. _ap-verify-results:

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -75,6 +75,8 @@ class _ProcessingParser(argparse.ArgumentParser):
     def __init__(self):
         # Help and documentation will be handled by main program's parser
         argparse.ArgumentParser.__init__(self, add_help=False)
+        self.add_argument("-j", "--processes", default=1, type=int,
+                          help="Number of processes to use.")
 
 
 class _ApVerifyParser(argparse.ArgumentParser):
@@ -179,12 +181,12 @@ def runApVerify(cmdLine=None):
         ingestDatasetGen3(args.dataset, workspace)
         log.info('Running pipeline...')
         # Gen 3 pipeline includes both AP and metrics
-        return runApPipeGen3(workspace, args)
+        return runApPipeGen3(workspace, args, processes=args.processes)
     else:
         workspace = WorkspaceGen2(args.output)
         ingestDataset(args.dataset, workspace)
         log.info('Running pipeline...')
-        apPipeResults = runApPipeGen2(workspace, args)
+        apPipeResults = runApPipeGen2(workspace, args, processes=args.processes)
         computeMetrics(workspace, apPipeResults.parsedCmd.id, args)
         return _getCmdLineExitStatus(apPipeResults.resultList)
 

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -65,6 +65,18 @@ class _InputOutputParser(argparse.ArgumentParser):
                            help='Handle the ap_verify dataset using the Gen 3 framework.')
 
 
+class _ProcessingParser(argparse.ArgumentParser):
+    """An argument parser for general run-time characteristics.
+
+    This parser is not complete, and is designed to be passed to another parser
+    using the `parent` parameter.
+    """
+
+    def __init__(self):
+        # Help and documentation will be handled by main program's parser
+        argparse.ArgumentParser.__init__(self, add_help=False)
+
+
 class _ApVerifyParser(argparse.ArgumentParser):
     """An argument parser for data needed by the main ap_verify program.
     """
@@ -74,7 +86,7 @@ class _ApVerifyParser(argparse.ArgumentParser):
             self,
             description='Executes the LSST DM AP pipeline and analyzes its performance using metrics.',
             epilog='',
-            parents=[_InputOutputParser(), ApPipeParser(), MetricsParser()],
+            parents=[_InputOutputParser(), _ProcessingParser(), ApPipeParser(), MetricsParser()],
             add_help=True)
 
 
@@ -92,7 +104,7 @@ class _IngestOnlyParser(argparse.ArgumentParser):
             'passing the same --output argument, or by other programs that accept '
             'Butler repositories as input.',
             epilog='',
-            parents=[_InputOutputParser()],
+            parents=[_InputOutputParser(), _ProcessingParser()],
             add_help=True)
 
 

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -178,7 +178,7 @@ def runApVerify(cmdLine=None):
 
     if args.useGen3:
         workspace = WorkspaceGen3(args.output)
-        ingestDatasetGen3(args.dataset, workspace)
+        ingestDatasetGen3(args.dataset, workspace, processes=args.processes)
         log.info('Running pipeline...')
         # Gen 3 pipeline includes both AP and metrics
         return runApPipeGen3(workspace, args, processes=args.processes)
@@ -235,7 +235,7 @@ def runIngestion(cmdLine=None):
 
     if args.useGen3:
         workspace = WorkspaceGen3(args.output)
-        ingestDatasetGen3(args.dataset, workspace)
+        ingestDatasetGen3(args.dataset, workspace, processes=args.processes)
     else:
         workspace = WorkspaceGen2(args.output)
         ingestDataset(args.dataset, workspace)

--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -55,6 +55,7 @@ class Dataset:
     """
 
     def __init__(self, datasetId):
+        self._id = datasetId
         # daf.persistence.Policy's behavior on missing keys is apparently undefined
         # test for __getattr__ *either* raising KeyError or returning None
         try:
@@ -229,6 +230,18 @@ class Dataset:
             raise RuntimeError('Dataset at ' + self.datasetRoot + 'is missing stub repo')
         if not _isRepo(self._stubInputRepo):
             raise RuntimeError('Stub repo at ' + self._stubInputRepo + 'is missing mapper file')
+
+    def __eq__(self, other):
+        """Test that two Dataset objects are equal.
+
+        Two objects are equal iff they refer to the same ap_verify dataset.
+        """
+        return self.datasetRoot == other.datasetRoot
+
+    def __repr__(self):
+        """A string representation that can be used to reconstruct the dataset.
+        """
+        return f"Dataset({self._id!r})"
 
     def makeCompatibleRepo(self, repoDir, calibRepoDir):
         """Set up a directory as a Gen 2 repository compatible with this ap_verify dataset.

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -463,6 +463,11 @@ class Gen3DatasetIngestTask(pipeBase.Task):
         self.makeSubtask("ingester", butler=self.workspace.workButler)
         self.makeSubtask("visitDefiner", butler=self.workspace.workButler)
 
+    # Overrides Task.__reduce__
+    def __reduce__(self):
+        baseArgs = super().__reduce__()[1]
+        return (self.__class__, (self.dataset, self.workspace, *baseArgs))
+
     def run(self):
         """Ingest the contents of a dataset into a Butler repository.
         """

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -59,8 +59,6 @@ class ApPipeParser(argparse.ArgumentParser):
                           help='An identifier for the data to process.')
         self.add_argument("-p", "--pipeline", default=defaultPipeline,
                           help="A custom version of the ap_verify pipeline (e.g., with different metrics).")
-        self.add_argument("-j", "--processes", default=1, type=int,
-                          help="Number of processes to use.")
         self.add_argument("--skip-pipeline", action="store_true",
                           help="Do not run the AP pipeline itself. This argument is useful "
                                "for testing metrics on a fixed data set.")
@@ -80,7 +78,7 @@ class ApPipeParser(argparse.ArgumentParser):
                     setattr(namespace, self.dest, [values])
 
 
-def runApPipeGen2(workspace, parsedCmdLine):
+def runApPipeGen2(workspace, parsedCmdLine, processes=1):
     """Run `ap_pipe` on this object's dataset.
 
     Parameters
@@ -89,6 +87,8 @@ def runApPipeGen2(workspace, parsedCmdLine):
         The abstract location containing input and output repositories.
     parsedCmdLine : `argparse.Namespace`
         Command-line arguments, including all arguments supported by `ApPipeParser`.
+    processes : `int`
+        The number of processes with which to call the AP pipeline
 
     Returns
     -------
@@ -112,7 +112,7 @@ def runApPipeGen2(workspace, parsedCmdLine):
             pipelineArgs.extend(["--id", *singleId.split(" ")])
     else:
         pipelineArgs.extend(["--id"])
-    pipelineArgs.extend(["--processes", str(parsedCmdLine.processes)])
+    pipelineArgs.extend(["--processes", str(processes)])
     pipelineArgs.extend(["--noExit"])
 
     if not parsedCmdLine.skip_pipeline:
@@ -132,7 +132,7 @@ def runApPipeGen2(workspace, parsedCmdLine):
     return results
 
 
-def runApPipeGen3(workspace, parsedCmdLine):
+def runApPipeGen3(workspace, parsedCmdLine, processes=1):
     """Run `ap_pipe` on this object's dataset.
 
     Parameters
@@ -141,6 +141,8 @@ def runApPipeGen3(workspace, parsedCmdLine):
         The abstract location containing input and output repositories.
     parsedCmdLine : `argparse.Namespace`
         Command-line arguments, including all arguments supported by `ApPipeParser`.
+    processes : `int`
+        The number of processes with which to call the AP pipeline
     """
     log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipeGen3')
 
@@ -159,7 +161,7 @@ def runApPipeGen3(workspace, parsedCmdLine):
     if parsedCmdLine.dataIds:
         for singleId in parsedCmdLine.dataIds:
             pipelineArgs.extend(["--data-query", singleId])
-    pipelineArgs.extend(["--processes", str(parsedCmdLine.processes)])
+    pipelineArgs.extend(["--processes", str(processes)])
     pipelineArgs.extend(["--register-dataset-types"])
 
     if not parsedCmdLine.skip_pipeline:

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -78,6 +78,17 @@ class Workspace(metaclass=abc.ABCMeta):
         mode = stat.S_IRWXU | stat.S_IRGRP | stat.S_IROTH  # a+r, u+rwx
         pathlib.Path(directory).mkdir(parents=True, exist_ok=True, mode=mode)
 
+    def __eq__(self, other):
+        """Test whether two workspaces are of the same type and have the
+        same location.
+        """
+        return type(self) == type(other) and self.workDir == other.workDir
+
+    def __repr__(self):
+        """A string representation that can be used to reconstruct the Workspace.
+        """
+        return f"{type(self).__name__}({self.workDir!r})"
+
     @property
     def workDir(self):
         """The absolute location of the workspace as a whole

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -45,6 +45,10 @@ class DatasetTestSuite(DataTestCase):
     def setUp(self):
         self._testbed = Dataset(DatasetTestSuite.datasetKey)
 
+    def testRepr(self):
+        # Required to match constructor call
+        self.assertEqual(repr(self._testbed), "Dataset(" + repr(self.datasetKey) + ")")
+
     def testDatasets(self):
         """Verify that a Dataset knows its supported datasets.
         """

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -22,6 +22,7 @@
 #
 
 import os
+import pickle
 import shutil
 import tempfile
 import unittest.mock
@@ -470,6 +471,19 @@ class IngestionTestSuiteGen3(DataTestCase):
             ingestion._findMatchingFiles(testDir, ['*.fits.gz'], exclude=['calib']),
             allFiles
         )
+
+    def testPickling(self):
+        """Test that a Gen3DatasetIngestTask can be pickled correctly.
+
+        This is needed for multiprocessing support.
+        """
+        stream = pickle.dumps(self.task)
+        copy = pickle.loads(stream)
+        self.assertEqual(self.task.getFullName(), copy.getFullName())
+        self.assertEqual(self.task.log.getName(), copy.log.getName())
+        # Equality for config ill-behaved; skip testing it
+        self.assertEqual(self.task.dataset, copy.dataset)
+        self.assertEqual(self.task.workspace, copy.workspace)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -380,40 +380,40 @@ class IngestionTestSuiteGen3(DataTestCase):
         """Test that ingesting science images given specific files adds them to a repository.
         """
         files = [os.path.join(self.dataset.rawLocation, datum['file']) for datum in self.rawData]
-        self.task._ingestRaws(files)
+        self.task._ingestRaws(files, processes=1)
         self.assertIngestedDataFiles(self.rawData, self.dataset.instrument.makeDefaultRawIngestRunName())
 
     def testDataDoubleIngest(self):
         """Test that re-ingesting science images raises RuntimeError.
         """
         files = [os.path.join(self.dataset.rawLocation, datum['file']) for datum in self.rawData]
-        self.task._ingestRaws(files)
+        self.task._ingestRaws(files, processes=1)
         with self.assertRaises(RuntimeError):
-            self.task._ingestRaws(files)
+            self.task._ingestRaws(files, processes=1)
 
     def testDataIngestDriver(self):
         """Test that ingesting science images starting from an abstract dataset adds them to a repository.
         """
-        self.task._ensureRaws()
+        self.task._ensureRaws(processes=1)
         self.assertIngestedDataFiles(self.rawData, self.dataset.instrument.makeDefaultRawIngestRunName())
 
     def testCalibIngestDriver(self):
         """Test that ingesting calibrations starting from an abstract dataset adds them to a repository.
         """
-        self.task._ensureRaws()  # Should not affect calibs, but would be run
+        self.task._ensureRaws(processes=1)  # Should not affect calibs, but would be run
         self.assertIngestedDataFiles(self.calibData, self.dataset.instrument.makeCollectionName("calib"))
 
     def testNoFileIngest(self):
         """Test that attempts to ingest nothing raise an exception.
         """
         with self.assertRaises(RuntimeError):
-            self.task._ingestRaws([])
+            self.task._ingestRaws([], processes=1)
 
     def testVisitDefinition(self):
         """Test that the final repository supports indexing by visit.
         """
-        self.task._ensureRaws()
-        self.task._defineVisits()
+        self.task._ensureRaws(processes=1)
+        self.task._defineVisits(processes=1)
 
         testId = {"visit": self.VISIT_ID, "instrument": self.INSTRUMENT, }
         exposures = list(self.butler.registry.queryDataIds("exposure", dataId=testId))
@@ -423,9 +423,9 @@ class IngestionTestSuiteGen3(DataTestCase):
     def testVisitDoubleDefinition(self):
         """Test that re-defining visits is guarded against.
         """
-        self.task._ensureRaws()
-        self.task._defineVisits()
-        self.task._defineVisits()  # must not raise
+        self.task._ensureRaws(processes=1)
+        self.task._defineVisits(processes=1)
+        self.task._defineVisits(processes=1)  # must not raise
 
         testId = {"visit": self.VISIT_ID, "instrument": self.INSTRUMENT, }
         exposures = list(self.butler.registry.queryDataIds("exposure", dataId=testId))
@@ -435,7 +435,7 @@ class IngestionTestSuiteGen3(DataTestCase):
         """Test that attempts to define visits with no exposures raise an exception.
         """
         with self.assertRaises(RuntimeError):
-            self.task._defineVisits()
+            self.task._defineVisits(processes=1)
 
     def testCopyConfigs(self):
         """Test that "ingesting" configs stores them in the workspace for later reference.

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -35,7 +35,8 @@ from lsst.ap.verify.workspace import WorkspaceGen2, WorkspaceGen3
 class WorkspaceGen2TestSuite(lsst.utils.tests.TestCase):
 
     def setUp(self):
-        self._testWorkspace = tempfile.mkdtemp()
+        # Use realpath to avoid link problems
+        self._testWorkspace = os.path.realpath(tempfile.mkdtemp())
         self._testbed = WorkspaceGen2(self._testWorkspace)
 
     def tearDown(self):
@@ -133,7 +134,8 @@ class WorkspaceGen2TestSuite(lsst.utils.tests.TestCase):
 class WorkspaceGen3TestSuite(lsst.utils.tests.TestCase):
 
     def setUp(self):
-        self._testWorkspace = tempfile.mkdtemp()
+        # Use realpath to avoid link problems
+        self._testWorkspace = os.path.realpath(tempfile.mkdtemp())
         self._testbed = WorkspaceGen3(self._testWorkspace)
 
     def tearDown(self):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -41,6 +41,23 @@ class WorkspaceGen2TestSuite(lsst.utils.tests.TestCase):
     def tearDown(self):
         shutil.rmtree(self._testWorkspace, ignore_errors=True)
 
+    def testRepr(self):
+        # Required to match constructor call
+        self.assertEqual(repr(self._testbed), "WorkspaceGen2(" + repr(self._testWorkspace) + ")")
+
+    def testEq(self):
+        copied = WorkspaceGen2(self._testWorkspace)
+        self.assertEqual(self._testbed, copied)
+
+        alternate = WorkspaceGen3(self._testWorkspace)
+        self.assertNotEqual(self._testbed, alternate)
+        self.assertNotEqual(copied, alternate)
+
+        with tempfile.TemporaryDirectory() as temp:
+            different = WorkspaceGen2(temp)
+            self.assertNotEqual(self._testbed, different)
+            self.assertNotEqual(copied, different)
+
     def _assertInDir(self, path, baseDir):
         """Test that ``path`` is a subpath of ``baseDir``.
         """
@@ -121,6 +138,23 @@ class WorkspaceGen3TestSuite(lsst.utils.tests.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self._testWorkspace, ignore_errors=True)
+
+    def testRepr(self):
+        # Required to match constructor call
+        self.assertEqual(repr(self._testbed), "WorkspaceGen3(" + repr(self._testWorkspace) + ")")
+
+    def testEq(self):
+        copied = WorkspaceGen3(self._testWorkspace)
+        self.assertEqual(self._testbed, copied)
+
+        alternate = WorkspaceGen2(self._testWorkspace)
+        self.assertNotEqual(self._testbed, alternate)
+        self.assertNotEqual(copied, alternate)
+
+        with tempfile.TemporaryDirectory() as temp:
+            different = WorkspaceGen3(temp)
+            self.assertNotEqual(self._testbed, different)
+            self.assertNotEqual(copied, different)
 
     def _assertInDir(self, path, baseDir):
         """Test that ``path`` is a subpath of ``baseDir``.


### PR DESCRIPTION
This PR implements multiprocessing in `Gen3DatasetIngestTask` after adding basic value support to the `Dataset` and `Workspace` classes to make them more unit-test-friendly. This required some refactoring of `ap_verify`'s command-line argument parser.