### PR TITLE
DM-26662: ap_verify import slow in Gen 3

### DIFF
--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -277,7 +277,10 @@ class Dataset:
         """
         # No way to tell makeRepo "create only what's missing"
         try:
-            repoConfig = dafButler.Butler.makeRepo(repoDir)
+            seedConfig = dafButler.Config()
+            # Checksums greatly slow importing of large repositories
+            seedConfig["datastore", "checksum"] = False
+            repoConfig = dafButler.Butler.makeRepo(repoDir, config=seedConfig)
             butler = dafButler.Butler(repoConfig, writeable=True)
             butler.import_(directory=self._preloadedRepo, filename=self._preloadedExport,
                            transfer="auto")


### PR DESCRIPTION
This PR creates the `ap_verify` repository without checksums, to ensure that copying the repository is a fast operation (minutes vs. hours, for large repositories). Testing suggests that `daf.butler.Config` silently ignores nonexistent keys, so the new code will work for both file-based and non-file datastores. However, this behavior doesn't seem to be documented anywhere.