### PR TITLE
DM-22663: Reimplement make_apdb.py for Gen 3

### DIFF
--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -170,7 +170,7 @@ class PipelineDriverTestSuiteGen2(lsst.utils.tests.TestCase):
 
         mockDb.assert_called_once()
         cmdLineArgs = self._getCmdLineArgs(mockDb.call_args)
-        self.assertIn("diaPipe.apdb.db_url=sqlite:///" + self.workspace.dbLocation, cmdLineArgs)
+        self.assertIn("db_url=sqlite:///" + self.workspace.dbLocation, cmdLineArgs)
 
         mockParse.assert_called_once()
         cmdLineArgs = self._getCmdLineArgs(mockParse.call_args)
@@ -263,7 +263,7 @@ class PipelineDriverTestSuiteGen3(lsst.utils.tests.TestCase):
 
         mockDb.assert_called_once()
         cmdLineArgs = self._getCmdLineArgs(mockDb.call_args)
-        self.assertIn("diaPipe.apdb.db_url=sqlite:///" + self.workspace.dbLocation, cmdLineArgs)
+        self.assertIn("db_url=sqlite:///" + self.workspace.dbLocation, cmdLineArgs)
 
         mockParse = mockFwk().parseAndRun
         mockParse.assert_called_once()


### PR DESCRIPTION
This PR updates `ap_verify`'s calls to `make_apdb.py` to use the APDB-centric config options introduced in lsst/ap_pipe#62.