### PR TITLE
DM-27857: Update ap_verify dataset conversion scripts

### DIFF
--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -13,11 +13,6 @@ tasks:
         config:
             apdb.isolation_level: READ_UNCOMMITTED
             doPackageAlerts: True
-    imageDifference:
-        class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
-        config:
-            # TODO: remove after ap_verify datasets follow RFC-741 conventions
-            connections.skyMap: "{skyMapName}Coadd_skyMap"
 contracts:
     # Metric inputs must match pipeline outputs
     - imageDifference.connections.coaddName == fracDiaSourcesToSciSources.connections.coaddName


### PR DESCRIPTION
This PR updates the dataset types assumed by the `ApVerify` pipeline, to be consistent with repositories created after merging lsst-dm/ap_verify_dataset_template#19.