### PR TITLE
DM-27325: Can't rerun ap_verify on same repository in Gen 3

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -41,6 +41,21 @@ Named arguments
 
 Required arguments are :option:`--dataset` and :option:`--output`.
 
+.. option:: --clean-run
+
+   **Rerun ap_verify in a clean Gen 3 run even if the workspace already exists. (Gen 3 only)**
+
+   By default, when ``ap_verify`` is run multiple times with the same :option:`--output` workspace, the previous run collection is reused to avoid repeating processing.
+   If this is undesirable (e.g., experimental config changes), this flag creates a new run, and the pipeline is run from the beginning.
+   This flag has no effect if :option:`--output` is a fresh directory.
+
+   .. note::
+
+      The ``--clean-run`` flag does *not* reset the alert production database,
+      as this is not something that can be done without knowledge of the
+      specific database system being used. If the database has been written to
+      by a previous run, clear it by hand before running with ``--clean-run``.
+
 .. option:: --id <dataId>
 
    **Butler data ID.**

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -504,7 +504,13 @@ class Gen3DatasetIngestTask(pipeBase.Task):
         # TODO: regex is workaround for DM-25945
         rawCollectionFilter = re.compile(self.dataset.instrument.makeDefaultRawIngestRunName())
         rawCollections = list(self.workspace.workButler.registry.queryCollections(rawCollectionFilter))
-        if rawCollections:
+        rawData = list(self.workspace.workButler.registry.queryDatasets(
+            'raw',
+            collections=rawCollections,
+            dataId={"instrument": self.dataset.instrument.getName()})) \
+            if rawCollections else []
+
+        if rawData:
             self.log.info("Raw images for %s were previously ingested, skipping...",
                           self.dataset.instrument.getName())
         else:

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -116,6 +116,10 @@ class DatasetIngestConfig(pexConfig.Config):
         doc="Map from a refcat name to a tar.gz file containing the sharded catalog. May be empty.",
     )
 
+    def setDefaults(self):
+        # Can't easily check for prior curated ingestion, so make it not matter
+        self.curatedCalibIngester.clobber = True
+
 
 class DatasetIngestTask(pipeBase.Task):
     """Task for automating ingestion of a ap_verify dataset.
@@ -300,6 +304,7 @@ class DatasetIngestTask(pipeBase.Task):
             The location containing all ingestion repositories.
         """
         for curated in self.config.curatedCalibPaths:
+            # Can't easily check for prior ingestion; workaround in config
             self.log.info("Ingesting curated calibs...")
             self._doIngestCuratedCalibs(workspace.dataRepo, workspace.calibRepo, curated)
             self.log.info("Curated calibs are now ingested in {0}".format(workspace.calibRepo))
@@ -319,7 +324,7 @@ class DatasetIngestTask(pipeBase.Task):
             a path in ``obs_*_data``.
         """
 
-        curatedargs = [repo, curatedPath, "--calib", calibRepo]
+        curatedargs = [repo, curatedPath, "--calib", calibRepo, "--ignore-ingested"]
         try:
             _runIngestTask(self.curatedCalibIngester, curatedargs)
         except sqlite3.IntegrityError as detail:

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -307,5 +307,5 @@ def _getCollectionArguments(workspace):
     inputs.update(butler.registry.queryCollections(re.compile(r"templates/\w+")))
 
     return ["--input", ",".join(inputs),
-            "--output-run", workspace.runName,
+            "--output-run", workspace.outputName,
             ]

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -31,6 +31,7 @@ __all__ = ["ApPipeParser", "runApPipeGen2", "runApPipeGen3"]
 
 import argparse
 import os
+import re
 
 import click.testing
 
@@ -296,6 +297,12 @@ def _getCollectionArguments(workspace):
         following the conventions of `sys.argv`.
     """
     # workspace.outputName is a chained collection containing all inputs
-    return ["--output", workspace.outputName,
+    args = ["--output", workspace.outputName,
             "--clobber-partial-outputs",
             ]
+
+    registry = workspace.workButler.registry
+    oldRuns = list(registry.queryCollections(re.compile(workspace.outputName + r"/\d+T\d+Z")))
+    if oldRuns:
+        args.extend(["--extend-run", "--skip-existing"])
+    return args

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -31,14 +31,12 @@ __all__ = ["ApPipeParser", "runApPipeGen2", "runApPipeGen3"]
 
 import argparse
 import os
-import re
 
 import click.testing
 
 import lsst.log
 from lsst.utils import getPackageDir
 import lsst.pipe.base as pipeBase
-import lsst.obs.base as obsBase
 import lsst.ctrl.mpexec.cli.pipetask
 import lsst.ap.pipe as apPipe
 from lsst.ap.pipe.make_apdb import makeApdb
@@ -297,15 +295,7 @@ def _getCollectionArguments(workspace):
         Command-line arguments calling ``--input`` or ``--output``,
         following the conventions of `sys.argv`.
     """
-    butler = workspace.workButler
-    # Hard-code the collection names because it's hard to infer the inputs from the Butler
-    inputs = {"skymaps", "refcats"}
-    for dimension in butler.registry.queryDataIds('instrument'):
-        instrument = obsBase.Instrument.fromName(dimension["instrument"], butler.registry)
-        inputs.add(instrument.makeDefaultRawIngestRunName())
-        inputs.add(instrument.makeCalibrationCollectionName())
-    inputs.update(butler.registry.queryCollections(re.compile(r"templates/\w+")))
-
-    return ["--input", ",".join(inputs),
-            "--output-run", workspace.outputName,
+    # workspace.outputName is a chained collection containing all inputs
+    return ["--output", workspace.outputName,
+            "--clobber-partial-outputs",
             ]

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -68,6 +68,9 @@ class ApPipeParser(argparse.ArgumentParser):
         self.add_argument("--skip-pipeline", action="store_true",
                           help="Do not run the AP pipeline itself. This argument is useful "
                                "for testing metrics on a fixed data set.")
+        self.add_argument("--clean-run", action="store_true",
+                          help="Run the pipeline with a new run collection, "
+                               "even if one already exists.")
 
     class AppendOptional(argparse.Action):
         """A variant of the built-in "append" action that ignores None values
@@ -160,7 +163,7 @@ def runApPipeGen3(workspace, parsedCmdLine, processes=1):
     # TODO: collections should be determined exclusively by Workspace.workButler,
     # but I can't find a way to hook that up to the graph builder. So use the CLI
     # for now and revisit once DM-26239 is done.
-    pipelineArgs.extend(_getCollectionArguments(workspace))
+    pipelineArgs.extend(_getCollectionArguments(workspace, reuse=(not parsedCmdLine.clean_run)))
     pipelineArgs.extend(_getConfigArgumentsGen3(workspace, parsedCmdLine))
     if parsedCmdLine.dataIds:
         for singleId in parsedCmdLine.dataIds:
@@ -281,7 +284,7 @@ def _getConfigArgumentsGen3(workspace, parsed):
     return args
 
 
-def _getCollectionArguments(workspace):
+def _getCollectionArguments(workspace, reuse):
     """Return the collections for running the Gen 3 AP Pipeline on this
     workspace, as command-line arguments.
 
@@ -289,6 +292,9 @@ def _getCollectionArguments(workspace):
     ----------
     workspace : `lsst.ap.verify.workspace.WorkspaceGen3`
         A Workspace with a Gen 3 repository.
+    reuse : `bool`
+        If true, use the previous run collection if one exists. Otherwise,
+        create a new run.
 
     Returns
     -------
@@ -303,6 +309,6 @@ def _getCollectionArguments(workspace):
 
     registry = workspace.workButler.registry
     oldRuns = list(registry.queryCollections(re.compile(workspace.outputName + r"/\d+T\d+Z")))
-    if oldRuns:
+    if reuse and oldRuns:
         args.extend(["--extend-run", "--skip-existing"])
     return args

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -272,8 +272,8 @@ class WorkspaceGen3(Workspace):
 
         self.mkdir(self.repo)
 
-        # Gen 3 name of the output run
-        self.runName = "ap_verify-output"
+        # Gen 3 name of the output
+        self.outputName = "ap_verify-output"
 
         # Lazy evaluation to optimize butlers
         self._workButler = None
@@ -313,7 +313,7 @@ class WorkspaceGen3(Workspace):
                     inputs.add(instrument.makeCalibrationCollectionName())
                 inputs.update(queryButler.registry.queryCollections(re.compile(r"templates/\w+")))
 
-                # should set run=self.runName, but this breaks quantum graph generation (DM-26246)
+                # should set run=self.outputName, but this breaks quantum graph generation (DM-26246)
                 self._workButler = dafButler.Butler(butler=queryButler, collections=inputs)
             except OSError as e:
                 raise RuntimeError(f"{self.repo} is not a Gen 3 repository") from e
@@ -329,7 +329,7 @@ class WorkspaceGen3(Workspace):
         """
         if self._analysisButler is None:
             try:
-                self._analysisButler = dafButler.Butler(self.repo, collections=self.runName,
+                self._analysisButler = dafButler.Butler(self.repo, collections=self.outputName,
                                                         writeable=False)
             except OSError as e:
                 raise RuntimeError(f"{self.repo} is not a Gen 3 repository") from e

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -223,6 +223,13 @@ class WorkspaceGen3TestSuite(lsst.utils.tests.TestCase):
         with self.assertRaises(RuntimeError):
             self._testbed.workButler
         lsst.daf.butler.Butler.makeRepo(self._testbed.repo)
+        # workButler definition currently requires valid collections; this
+        # should be an implementation detail.
+        registry = lsst.daf.butler.Butler(self._testbed.repo, writeable=True).registry
+        registry.registerCollection('refcats', lsst.daf.butler.CollectionType.RUN)
+        registry.registerCollection('skymaps', lsst.daf.butler.CollectionType.RUN)
+        registry.registerCollection('templates/foo', lsst.daf.butler.CollectionType.RUN)
+
         # Can't really test Butler's state, so just make sure it exists
         self.assertTrue(self._testbed.workButler.isWriteable())
 


### PR DESCRIPTION
This PR fixes bugs in both Gen 2 and Gen 3 that prevented `ap_verify` from being rerun for the same data and output workspace, so long as the previous run did not touch the APDB. Supporting multiple runs for the same database is a more challenging problem that would likely require extra checks in `DiaPipelineTask`.