### PR TITLE
DM-24806: Lift key ap_verify classes into lsst.ap.verify namespace

### DIFF
--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -28,7 +28,7 @@ Using the `Cosmos PDR2`_ CI dataset as an example, one can run :command:`ap_veri
 
 Here the inputs are:
 
-* :command:`ap_verify_ci_cosmos_pdr2` is the ``ap_verify`` :ref:`dataset <ap-verify-datasets> to process,
+* :command:`ap_verify_ci_cosmos_pdr2` is the ``ap_verify`` :ref:`dataset <ap-verify-datasets>` to process,
 * :option:`--gen2` specifies to process the dataset using the Gen 2 pipeline framework,
 * :command:`visit=59150^59160 filter=HSC-G` is the :ref:`dataId<command-line-task-dataid-howto-about-dataid-keys>` to process,
 

--- a/python/lsst/ap/verify/__init__.py
+++ b/python/lsst/ap/verify/__init__.py
@@ -1,6 +1,10 @@
 from .version import *
+from .dataset import *
+from .workspace import *
+from .ingestion import *
+from .pipeline_driver import *
+from .metrics import *
 from .ap_verify import *
-from .ingestion import DatasetIngestConfig
 
 import pkgutil, lsstimport
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/ap/verify/config.py
+++ b/python/lsst/ap/verify/config.py
@@ -21,6 +21,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+__all__ = ["Config"]
+
 from lsst.daf.persistence import Policy
 
 

--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -21,6 +21,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+__all__ = ["Dataset"]
+
 import os
 import warnings
 

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -102,8 +102,9 @@ def runApPipeGen2(workspace, parsedCmdLine, processes=1):
 
     Returns
     -------
-    apPipeReturn : `Struct`
-        The `Struct` returned from `~lsst.ap.pipe.ApPipeTask.parseAndRun` with
+    apPipeReturn : `lsst.pipe.base.Struct`
+        The `~lsst.pipe.base.Struct` returned from
+        `~lsst.ap.pipe.ApPipeTask.parseAndRun` with
         ``doReturnResults=False``. This object is valid even if
         `~lsst.ap.pipe.ApPipeTask` was never run.
     """

--- a/python/lsst/ap/verify/testUtils.py
+++ b/python/lsst/ap/verify/testUtils.py
@@ -24,6 +24,8 @@
 """Common code for ap_verify unit tests.
 """
 
+__all__ = ["DataTestCase"]
+
 import unittest
 
 import lsst.utils.tests

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -21,6 +21,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+__all__ = ["Workspace", "WorkspaceGen2", "WorkspaceGen3"]
+
 import abc
 import os
 import pathlib


### PR DESCRIPTION
This PR adds all classes that were public to a given module to the `ap.verify` `__init__.py` file, and fixes any documentation errors that appeared.