### PR TITLE
DM-29344: Investigate the CI differences between Gen 2 and 3 in COSMOS field

### DIFF
--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -300,6 +300,9 @@ def _getConfigArgumentsGen3(workspace, parsed):
         "--config-file", "calibrate:" + os.path.join(workspace.configDir, "calibrate.py"),
         "--config-file", "imageDifference:" + os.path.join(workspace.configDir, "imageDifference.py"),
     ])
+    # TODO: this config should not be needed either after DM-26140
+    if os.path.exists(os.path.join(workspace.configDir, "isr.py")):
+        args.extend(["--config-file", "isr:" + os.path.join(workspace.configDir, "isr.py"), ])
     # TODO: reverse-engineering the instrument should not be needed after DM-26140
     # pipetask will crash if there is more than one instrument
     for idRecord in workspace.workButler.registry.queryDataIds("instrument").expanded():


### PR DESCRIPTION
This PR loads the ap_verify-style dataset's `config/isr.py` if it exists.

This helps ensure gen2 and gen3 isr config parity. In practice, DECam datasets don't have isr configs, but HSC ones do, and for gen2 to work, we need to run ap_verify with the brighter-fatter correction turned off.