### PR TITLE
DM-27032: Create deblended source metric

### DIFF
--- a/config/default_image_metrics.py
+++ b/config/default_image_metrics.py
@@ -2,6 +2,7 @@ from itertools import chain
 from lsst.verify.tasks.commonMetrics import TimingMetricConfig, MemoryMetricConfig
 # Import these modules to ensure the metrics are registered
 import lsst.ip.diffim.metrics  # noqa: F401
+import lsst.pipe.tasks.metrics  # noqa: F401
 import lsst.ap.association.metrics  # noqa: F401
 
 metadataConfigs = ["numNewDiaObjects",
@@ -9,6 +10,7 @@ metadataConfigs = ["numNewDiaObjects",
                    "fracUpdatedDiaObjects"]
 config.measurers = ["timing", "memory",
                     "numSciSources", "fracDiaSourcesToSciSources",
+                    "numDeblendedSciSources", "numDeblendChildSciSources",
                     ] + metadataConfigs
 
 timingConfigs = {

--- a/pipelines/MetricsMisc.yaml
+++ b/pipelines/MetricsMisc.yaml
@@ -22,3 +22,7 @@ tasks:
         class: lsst.ip.diffim.metrics.NumberSciSourcesMetricTask
     fracDiaSourcesToSciSources:
         class: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask
+    numDeblendedSciSources:
+        class: lsst.pipe.tasks.metrics.NumberDeblendedSourcesMetricTask
+    numDeblendChildSciSources:
+        class: lsst.pipe.tasks.metrics.NumberDeblendChildSourcesMetricTask


### PR DESCRIPTION
This PR adds new metrics from lsst/pipe_tasks#512 to the default Gen 2 and Gen 3 `ap_verify` pipelines.