### PR TITLE
DM-30057: AP timing metrics out of date

### DIFF
--- a/config/default_image_metrics.py
+++ b/config/default_image_metrics.py
@@ -24,7 +24,7 @@ timingConfigs = {
     "apPipe:differencer:detection.run": "meas_algorithms.SourceDetectionTime",
     "apPipe:differencer:measurement.run": "ip_diffim.DipoleFitTime",
     "apPipe:diaPipe.run": "ap_association.DiaPipelineTime",
-    "apPipe:diaPipe:diaSourceDpddifier.run": "ap_association.MapDiaSourceTime",
+    "apPipe:transformDiaSrcCat.run": "ap_association.MapDiaSourceTime",
     "apPipe:diaPipe:diaCatalogLoader.run": "ap_association.LoadDiaCatalogsTime",
     "apPipe:diaPipe:associator.run": "ap_association.AssociationTime",
     "apPipe:diaPipe:diaForcedSource.run": "ap_association.DiaForcedSourceTime",

--- a/pipelines/MetricsRuntime.yaml
+++ b/pipelines/MetricsRuntime.yaml
@@ -79,13 +79,13 @@ tasks:
             connections.metric: DiaPipelineTime
             connections.labelName: diaPipe
             target: diaPipe.run
-    timing_diaPipe_diaSourceDpddifier:
+    timing_transformDiaSrcCat:
         class: lsst.verify.tasks.commonMetrics.TimingMetricTask
         config:
             connections.package: ap_association
             connections.metric: MapDiaSourceTime
-            connections.labelName: diaPipe
-            target: diaPipe:diaSourceDpddifier.run
+            connections.labelName: transformDiaSrcCat
+            target: transformDiaSrcCat.run
     timing_diaPipe_diaCatalogLoader:
         class: lsst.verify.tasks.commonMetrics.TimingMetricTask
         config:


### PR DESCRIPTION
This PR remaps the `MapDiaSourceTime` metric from `diaPipe.diaSourceDpddifier` to `transformDiaSrcCat`, a roughly equivalent(?) task.