### PR TITLE
DM-29856: Switch ap_verify.py to Gen 3 by default

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -63,13 +63,17 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    Specify data ID to process.
    If using :option:`--gen2`, this should use :doc:`data ID syntax </modules/lsst.pipe.base/command-line-task-dataid-howto>`, such as ``--data-query "visit=12345 ccd=1..6 filter=g"``.
    If using :option:`--gen3`, this should use :ref:`dimension expression syntax <daf_butler_dimension_expressions>`, such as ``--data-query "visit=12345 and detector in (1..6) and band='g'"``.
-   The ``-id`` form of this argument is for consistency with Gen 2 command-line tasks, and is deprecated.
 
    Multiple copies of this argument are allowed.
    For compatibility with the syntax used by command line tasks, this flag with no argument processes all data IDs.
 
    If this argument is omitted, then all data IDs in the dataset will be processed.
    
+   .. warning::
+
+      The ``--id`` form of this argument is for consistency with Gen 2 command-line tasks, and is deprecated.
+      It will be removed after Science Pipelines release 23.
+
 .. option:: --dataset <dataset_package>
 
    **Input dataset package.**
@@ -92,6 +96,10 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    For the Gen 3 equivalent to this option, see :option:`--pipeline`.
    See also :doc:`new-metrics`.
 
+   .. warning::
+
+      Support for Gen 2 processing is deprecated and will be removed after Science Pipelines release 23.
+
 .. option:: --db, --db_url
 
    **Target Alert Production Database**
@@ -109,6 +117,10 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
    These optional flags run either the Gen 2 pipeline (`~lsst.ap.pipe.ApPipeTask`), or the Gen 3 pipeline (:file:`apPipe.yaml`).
    If neither flag is provided, the Gen 3 pipeline will be run.
+
+   .. warning::
+
+      Support for Gen 2 processing is deprecated and will be removed after Science Pipelines release 23.
 
 .. option:: -h, --help
 
@@ -134,6 +146,10 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    For the Gen 3 equivalent to this option, see :option:`--pipeline`.
    See also :doc:`new-metrics`.
 
+   .. warning::
+
+      Support for Gen 2 processing is deprecated and will be removed after Science Pipelines release 23.
+
 .. option:: --metrics-file <filename>
 
    **Output metrics file. (Gen 2 only)**
@@ -141,6 +157,10 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    The template for a file to contain metrics measured by ``ap_verify``, in a format readable by the :doc:`lsst.verify</modules/lsst.verify/index>` framework.
    The string ``{dataId}`` shall be replaced with the data ID associated with the job, and its use is strongly recommended.
    If omitted, the output will go to files named after ``ap_verify.{dataId}.verify.json`` in the user's working directory.
+
+   .. warning::
+
+      Support for Gen 2 processing is deprecated and will be removed after Science Pipelines release 23.
 
 .. option:: --output <workspace_dir>
 

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -56,27 +56,20 @@ Required arguments are :option:`--dataset` and :option:`--output`.
       specific database system being used. If the database has been written to
       by a previous run, clear it by hand before running with ``--clean-run``.
 
-.. option:: --id <dataId>
+.. option:: -d, --data-query, --id <dataId>
 
    **Butler data ID.**
 
    Specify data ID to process.
-   If using :option:`--gen2`, this should use :doc:`data ID syntax </modules/lsst.pipe.base/command-line-task-dataid-howto>`, such as ``--id "visit=12345 ccd=1..6 filter=g"``.
-   If using :option:`--gen3`, this should use :ref:`dimension expression syntax <daf_butler_dimension_expressions>`, such as ``--id "visit=12345 and detector in (1..6) and band='g'"``.
-   Consider using :option:`--data-query` instead of ``--id`` for forward-compatibility and consistency with Gen 3 pipelines.
+   If using :option:`--gen2`, this should use :doc:`data ID syntax </modules/lsst.pipe.base/command-line-task-dataid-howto>`, such as ``--data-query "visit=12345 ccd=1..6 filter=g"``.
+   If using :option:`--gen3`, this should use :ref:`dimension expression syntax <daf_butler_dimension_expressions>`, such as ``--data-query "visit=12345 and detector in (1..6) and band='g'"``.
+   The ``-id`` form of this argument is for consistency with Gen 2 command-line tasks, and is deprecated.
 
    Multiple copies of this argument are allowed.
-   For compatibility with the syntax used by command line tasks, ``--id`` with no argument processes all data IDs.
+   For compatibility with the syntax used by command line tasks, this flag with no argument processes all data IDs.
 
    If this argument is omitted, then all data IDs in the dataset will be processed.
    
-.. option:: -d, --data-query <dataId>
-
-   **Butler data ID.**
-
-   This option is identical to :option:`--id`, and will become the primary data ID argument as Gen 2 is retired.
-   It is recommended over :option:`--id` for :option:`--gen3` runs.
-
 .. option:: --dataset <dataset_package>
 
    **Input dataset package.**

--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -115,13 +115,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    **Choose Gen 2 or Gen 3 processing.**
 
    These optional flags run either the Gen 2 pipeline (`~lsst.ap.pipe.ApPipeTask`), or the Gen 3 pipeline (:file:`apPipe.yaml`).
-   If neither flag is provided, the Gen 2 pipeline will be run.
-
-   .. note::
-
-      The current default is provided for backward-compatibility with old scripts that assumed Gen 2 processing.
-      The default will change to ``--gen3`` once Gen 3 processing is officially supported by the Science Pipelines, at which point Gen 2 support will be deprecated.
-      Until the default stabilizes, users should be explicit about which pipeline they wish to run.
+   If neither flag is provided, the Gen 3 pipeline will be run.
 
 .. option:: -h, --help
 

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -59,10 +59,10 @@ class _InputOutputParser(argparse.ArgumentParser):
         gen23 = self.add_mutually_exclusive_group()
         # Because store_true and store_false use the same dest, add explicit
         # default to avoid ambiguity.
-        gen23.add_argument('--gen2', dest='useGen3', action='store_false', default=False,
+        gen23.add_argument('--gen2', dest='useGen3', action='store_false', default=True,
                            help='Handle the ap_verify dataset using the Gen 2 framework (default).')
-        gen23.add_argument('--gen3', dest='useGen3', action='store_true', default=False,
-                           help='Handle the ap_verify dataset using the Gen 3 framework.')
+        gen23.add_argument('--gen3', dest='useGen3', action='store_true', default=True,
+                           help='Handle the ap_verify dataset using the Gen 3 framework (default).')
 
 
 class _ProcessingParser(argparse.ArgumentParser):

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -31,6 +31,7 @@ __all__ = ["runApVerify", "runIngestion"]
 
 import argparse
 import re
+import warnings
 
 import lsst.log
 
@@ -91,6 +92,14 @@ class _ApVerifyParser(argparse.ArgumentParser):
             parents=[_InputOutputParser(), _ProcessingParser(), ApPipeParser(), MetricsParser()],
             add_help=True)
 
+    def parse_args(self, args=None, namespace=None):
+        namespace = super().parse_args(args, namespace)
+        # Code duplication; too hard to implement at shared _InputOutputParser level
+        if not namespace.useGen3:
+            warnings.warn("The --gen2 flag is deprecated; it will be removed after release 23.",
+                          category=FutureWarning)
+        return namespace
+
 
 class _IngestOnlyParser(argparse.ArgumentParser):
     """An argument parser for data needed by dataset ingestion.
@@ -108,6 +117,14 @@ class _IngestOnlyParser(argparse.ArgumentParser):
             epilog='',
             parents=[_InputOutputParser(), _ProcessingParser()],
             add_help=True)
+
+    def parse_args(self, args=None, namespace=None):
+        namespace = super().parse_args(args, namespace)
+        # Code duplication; too hard to implement at shared _InputOutputParser level
+        if not namespace.useGen3:
+            warnings.warn("The --gen2 flag is deprecated; it will be removed after release 23.",
+                          category=FutureWarning)
+        return namespace
 
 
 class _FormattedType:

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -138,9 +138,9 @@ class CommandLineTestSuite(lsst.ap.verify.testUtils.DataTestCase):
         """
         minArgs = f'--dataset {self.testDataset} --output tests/output/foo '
 
-        # Default currently Gen 2, will become Gen 3 later
+        # Default is Gen 3
         parsedDefault = self._parseString(minArgs)
-        self.assertFalse(parsedDefault.useGen3)
+        self.assertTrue(parsedDefault.useGen3)
 
         parsedGen2 = self._parseString(minArgs + '--gen2')
         self.assertFalse(parsedGen2.useGen3)


### PR DESCRIPTION
This PR causes `ap_verify.py` and `ingest-dataset.py` to run with Gen 3 rather than Gen 2 when no generation is explicitly provided. It also updates the documentation to be less Gen 2-centric.