### PR TITLE
DM-29341: Enable running Fakes in CI for ap_verify

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,2 @@
-Copyright 2017-2019 University of Washington
+Copyright 2017-2021 University of Washington
+Copyright 2020 The Trustees of Princeton University

--- a/bin/run_ci_dataset.sh
+++ b/bin/run_ci_dataset.sh
@@ -35,19 +35,21 @@ print_error() {
 
 usage() {
     print_error
-    print_error "Usage: $0 -d DATASET [-g NUM] [-h]"
+    print_error "Usage: $0 -d DATASET [-g NUM] [-p PATH] [-h]"
     print_error
     print_error "Specific options:"
     print_error "   -d          Dataset name"
     print_error "   -g          Middleware generation number (int)"
+    print_error "   -p          Pipeline to run (Gen 3 only)"
     print_error "   -h          show this message"
     exit 1
 }
 
-while getopts "d:g:h" option; do
+while getopts "d:g:p:h" option; do
     case "$option" in
         d)  DATASET="$OPTARG";;
         g)  GEN="$OPTARG";;
+        p)  PIPE="$OPTARG";;
         h)  usage;;
         *)  usage;;
     esac
@@ -59,6 +61,9 @@ if [[ -z "${DATASET}" ]]; then
 fi
 if [[ -n "${GEN}" ]]; then
     GEN="--gen${GEN}"
+fi
+if [[ -n "${PIPE}" ]]; then
+    PIPE="--pipeline ${PIPE}"
 fi
 shift $((OPTIND-1))
 
@@ -88,6 +93,7 @@ NUMPROC=${NUMPROC:-$((sys_proc < max_proc ? sys_proc : max_proc))}
 echo "Running ap_verify on ${DATASET} ${GEN}..."
 ap_verify.py --dataset "${DATASET}" \
     ${GEN} \
+    ${PIPE} \
     --output "${WORKSPACE}" \
     --processes "${NUMPROC}" \
     --metrics-file "${WORKSPACE}/ap_verify.{dataId}.verify.json" \

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -28,6 +28,10 @@ tasks:
         config:
             # Always prefer decorrelation; may eventually become ImageDifferenceTask default
             connections.fakesType: "fakes_"
+    transformDiaSrcCat:
+        class: lsst.ap.association.TransformDiaSourceCatalogTask
+        config:
+            connections.fakesType: "fakes_"
     diaPipe:
         # TODO: how to prevent duplication with ApPipe definition?
         class: lsst.ap.association.DiaPipelineTask

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -26,7 +26,6 @@ tasks:
     imageDifference:
         class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
         config:
-            # Always prefer decorrelation; may eventually become ImageDifferenceTask default
             connections.fakesType: "fakes_"
     transformDiaSrcCat:
         class: lsst.ap.association.TransformDiaSourceCatalogTask


### PR DESCRIPTION
This PR fixes some bugs in the existing `Fakes` pipeline and adds a flag to the CI bridge script for choosing a non-default pipeline. This is partly for forward-compatibility with RFC-775, which is expected to make having a single (or pair of) universal pipeline untenable.