### PR TITLE
DM-30563: ap_verify failing to find dataset type fakes_deepDiff_warpedExp

### DIFF
--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -17,8 +17,12 @@ tasks:
             connections.coaddName: deep
             # TODO: redundant connection definitions workaround for DM-30210
             connections.coaddExposures: deepCoadd
+            connections.outputSchema: deepDiff_diaSrc_schema
             connections.subtractedExposure: deepDiff_differenceExp
+            connections.scoreExposure: deepDiff_scoreExp
             connections.warpedExposure: deepDiff_warpedExp
+            connections.matchedExposure: deepDiff_matchedExp
+            connections.diaSources: deepDiff_diaSrc
             # TODO: end DM-30210 workaround
     transformDiaSrcCat:
         class: lsst.ap.association.TransformDiaSourceCatalogTask
@@ -32,7 +36,6 @@ tasks:
             connections.diaSourceTable: deepDiff_diaSrcTable
             # TODO: end DM-30210 workaround
     diaPipe:
-        # TODO: how to prevent duplication with ApPipe definition?
         class: lsst.ap.association.DiaPipelineTask
         config:
             apdb.isolation_level: READ_UNCOMMITTED
@@ -41,6 +44,8 @@ tasks:
             connections.coaddName: deep
             # TODO: redundant connection definitions workaround for DM-30210
             connections.diaSourceTable: deepDiff_diaSrcTable
+            connections.diffIm: deepDiff_differenceExp
+            connections.warpedExposure: deepDiff_warpedExp
             connections.associatedDiaSources: deepDiff_assocDiaSrcTable
             # TODO: end DM-30210 workaround
 contracts:

--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -10,29 +10,39 @@ tasks:
     imageDifference:
         class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
         config:
-            coaddName: deep
-            getTemplate.coaddName: deep
+            # All extant datasets use deep templates
+            # TODO: move to dataset configs in DM-26140
+            coaddName: deep              # Can be removed once ImageDifference no longer supports Gen 2
+            getTemplate.coaddName: deep  # Can be removed once ImageDifference no longer supports Gen 2
             connections.coaddName: deep
+            # TODO: redundant connection definitions workaround for DM-30210
             connections.coaddExposures: deepCoadd
             connections.subtractedExposure: deepDiff_differenceExp
             connections.warpedExposure: deepDiff_warpedExp
+            # TODO: end DM-30210 workaround
     transformDiaSrcCat:
         class: lsst.ap.association.TransformDiaSourceCatalogTask
         config:
+            # TODO: move to dataset configs in DM-26140
             connections.coaddName: deep
+            # TODO: redundant connection definitions workaround for DM-30210
             connections.diaSourceSchema: deepDiff_diaSrc_schema
             connections.diaSourceCat: deepDiff_diaSrc
             connections.diffIm: deepDiff_differenceExp
             connections.diaSourceTable: deepDiff_diaSrcTable
+            # TODO: end DM-30210 workaround
     diaPipe:
         # TODO: how to prevent duplication with ApPipe definition?
         class: lsst.ap.association.DiaPipelineTask
         config:
             apdb.isolation_level: READ_UNCOMMITTED
             doPackageAlerts: True
+            # TODO: move to dataset configs in DM-26140
             connections.coaddName: deep
+            # TODO: redundant connection definitions workaround for DM-30210
             connections.diaSourceTable: deepDiff_diaSrcTable
             connections.associatedDiaSources: deepDiff_assocDiaSrcTable
+            # TODO: end DM-30210 workaround
 contracts:
     # Metric inputs must match pipeline outputs
     - imageDifference.connections.coaddName == fracDiaSourcesToSciSources.connections.coaddName

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -27,16 +27,44 @@ tasks:
         class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
         config:
             connections.fakesType: "fakes_"
+            # TODO: redundant connection definitions workaround for DM-30210
+            # TODO: move hardcoding of "deep" to dataset configs in DM-26140
+            connections.coaddName: deep  # For file-level consistency; hardcoded values force "deep" anyway
+            connections.exposure: fakes_calexp
+            connections.coaddExposures: fakes_deepCoadd
+            connections.dcrCoadds: fakes_dcrCoadd
+            connections.outputSchema: fakes_deepDiff_diaSrc_schema
+            connections.subtractedExposure: fakes_deepDiff_differenceExp
+            connections.scoreExposure: fakes_deepDiff_scoreExp
+            connections.warpedExposure: fakes_deepDiff_warpedExp
+            connections.matchedExposure: fakes_deepDiff_matchedExp
+            connections.diaSources: fakes_deepDiff_diaSrc
+            # TODO: end DM-30210 workaround
     transformDiaSrcCat:
         class: lsst.ap.association.TransformDiaSourceCatalogTask
         config:
             connections.fakesType: "fakes_"
+            # TODO: redundant connection definitions workaround for DM-30210
+            # TODO: move hardcoding of "deep" to dataset configs in DM-26140
+            connections.coaddName: deep  # For file-level consistency; hardcoded values force "deep" anyway
+            connections.diaSourceSchema: fakes_deepDiff_diaSrc_schema
+            connections.diaSourceCat: fakes_deepDiff_diaSrc
+            connections.diffIm: fakes_deepDiff_differenceExp
+            connections.diaSourceTable: fakes_deepDiff_diaSrcTable
+            # TODO: end DM-30210 workaround
     diaPipe:
-        # TODO: how to prevent duplication with ApPipe definition?
         class: lsst.ap.association.DiaPipelineTask
         config:
             doWriteAssociatedSources: True
             connections.fakesType: "fakes_"
+            # TODO: redundant connection definitions workaround for DM-30210
+            # TODO: move hardcoding of "deep" to dataset configs in DM-26140
+            connections.coaddName: deep  # For file-level consistency; hardcoded values force "deep" anyway
+            connections.diaSourceTable: fakes_deepDiff_diaSrcTable
+            connections.diffIm: fakes_deepDiff_differenceExp
+            connections.warpedExposure: fakes_deepDiff_warpedExp
+            connections.associatedDiaSources: fakes_deepDiff_assocDiaSrc
+            # TODO: end DM-30210 workaround
     matchFakes:
         class: lsst.ap.pipe.matchApFakes.MatchApFakesTask
         config:


### PR DESCRIPTION
This PR updates `ApVerify.yaml` to match the changes in lsst/ap_pipe#81, and updates `ApVerifyWithFakes.yaml` with analogous changes.