### PR TITLE
DM-30776: Move MatchApFakesTask to pipe_tasks

### DIFF
--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -66,7 +66,7 @@ tasks:
             connections.associatedDiaSources: fakes_deepDiff_assocDiaSrc
             # TODO: end DM-30210 workaround
     matchFakes:
-        class: lsst.ap.pipe.matchApFakes.MatchApFakesTask
+        class: lsst.pipe.tasks.matchFakes.MatchFakesTask
         config:
             matchDistanceArcseconds: 0.1
     fracDiaSourcesToSciSources:


### PR DESCRIPTION
This PR updates the fakes pipeline to use the new `pipe.tasks.MatchFakesTask` added in lsst/pipe_tasks#537.