### PR TITLE
DM-31180: Force printing of pipeline logs.

### DIFF
--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -152,6 +152,13 @@ def runApPipeGen3(workspace, parsedCmdLine, processes=1):
         Command-line arguments, including all arguments supported by `ApPipeParser`.
     processes : `int`
         The number of processes with which to call the AP pipeline
+
+    Returns
+    -------
+    code : `int`
+        An error code that is zero if the pipeline ran without problems, or
+        nonzero if there were errors. The exact meaning of nonzereo values
+        is an implementation detail.
     """
     log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipeGen3')
 

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -32,8 +32,7 @@ __all__ = ["ApPipeParser", "runApPipeGen2", "runApPipeGen3"]
 import argparse
 import os
 import re
-
-import click.testing
+import subprocess
 
 import lsst.log
 from lsst.utils import getPackageDir
@@ -158,7 +157,7 @@ def runApPipeGen3(workspace, parsedCmdLine, processes=1):
 
     makeApdb(_getApdbArguments(workspace, parsedCmdLine))
 
-    pipelineArgs = ["run",
+    pipelineArgs = ["pipetask", "run",
                     "--butler-config", workspace.repo,
                     "--pipeline", parsedCmdLine.pipeline,
                     ]
@@ -175,16 +174,12 @@ def runApPipeGen3(workspace, parsedCmdLine, processes=1):
     pipelineArgs.extend(["--graph-fixup", "lsst.ap.verify.pipeline_driver._getExecOrder"])
 
     if not parsedCmdLine.skip_pipeline:
-        # CliRunner is an unsafe workaround for DM-26239
-        runner = click.testing.CliRunner()
+        # subprocess is an unsafe workaround for DM-26239
         # TODO: generalize this code in DM-26028
         # TODO: work off of workspace.workButler after DM-26239
-        results = runner.invoke(lsst.ctrl.mpexec.cli.pipetask.cli, pipelineArgs)
-        if results.exception:
-            raise RuntimeError("Pipeline failed.") from results.exception
-
+        results = subprocess.run(pipelineArgs, capture_output=False, shell=False, check=False)
         log.info('Pipeline complete.')
-        return results.exit_code
+        return results.returncode
     else:
         log.info('Skipping AP pipeline entirely.')
 


### PR DESCRIPTION
This PR removes the `CliRunner` driver for Gen 3 `ap_verify` and replaces it with a direct `subprocess` call. (Looking back at the discussion that decided to use `CliRunner`, it appears `subprocess` was not even mentioned except as a joke...)