### PR TITLE
DM-30349: Don't count fake sources in non-fakes metrics

### DIFF
--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -4,6 +4,8 @@
 description: Fully instrumented AP pipeline with fakes
 imports:
     - location: $AP_VERIFY_DIR/pipelines/ApVerify.yaml
+      exclude:
+          - fracDiaSourcesToSciSources  # Selectively turn off this task's contracts
     - location: $AP_VERIFY_DIR/pipelines/MetricsForFakes.yaml
 tasks:
     createFakes:
@@ -93,9 +95,8 @@ tasks:
         config:
             matchDistanceArcseconds: 0.1
     fracDiaSourcesToSciSources:
+        # Uses output of imageDifferenceNoFakes
         class: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask
-        config:
-            connections.fakesType: "fakes_"
 contracts:
     # Metric inputs must match pipeline outputs
     - createFakes.connections.fakesType == coaddFakes.connections.fakesType
@@ -113,3 +114,5 @@ contracts:
     - coaddFakes.connections.coaddName == apFakesCompletenessMag20t22.connections.coaddName
     - coaddFakes.connections.coaddName == apFakesCompletenessMag22t24.connections.coaddName
     - coaddFakes.connections.coaddName == apFakesCompletenessMag24t26.connections.coaddName
+    - imageDifferenceNoFakes.connections.coaddName == fracDiaSourcesToSciSources.connections.coaddName
+    - imageDifferenceNoFakes.connections.fakesType == fracDiaSourcesToSciSources.connections.fakesType

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -97,6 +97,30 @@ tasks:
     fracDiaSourcesToSciSources:
         # Uses output of imageDifferenceNoFakes
         class: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask
+    timing_imageDifference:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.labelName: imageDifferenceNoFakes
+    timing_imageDifference_astrometer:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.labelName: imageDifferenceNoFakes
+    timing_imageDifference_register:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.labelName: imageDifferenceNoFakes
+    timing_imageDifference_subtract:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.labelName: imageDifferenceNoFakes
+    timing_imageDifference_detection:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.labelName: imageDifferenceNoFakes
+    timing_imageDifference_measurement:
+        class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+        config:
+            connections.labelName: imageDifferenceNoFakes
 contracts:
     # Metric inputs must match pipeline outputs
     - createFakes.connections.fakesType == coaddFakes.connections.fakesType

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -23,6 +23,28 @@ tasks:
         config:
             insertFakes.doSubSelectSources: True
             insertFakes.sourceSelectionColName: "isVisitSource"
+    # Contracts require imageDifference, transformDiaSrc, and diaPipe to have matching configs.
+    # Since diaPipe must include fakes (see below), do non-fakes processing with non-standard names.
+    imageDifferenceNoFakes:
+        class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+        config:
+            doWriteWarpedExp: True       # Required for packaging alerts in diaPipe
+            doSkySources: True
+            # TODO: move hardcoding of "deep" to dataset configs in DM-26140
+            coaddName: deep              # Can be removed once ImageDifference no longer supports Gen 2
+            getTemplate.coaddName: deep  # Can be removed once ImageDifference no longer supports Gen 2
+            connections.coaddName: deep
+            # TODO: redundant connection definitions workaround for DM-30210
+            connections.exposure: calexp
+            connections.coaddExposures: deepCoadd
+            connections.dcrCoadds: dcrCoadd
+            connections.outputSchema: deepDiff_diaSrc_schema
+            connections.subtractedExposure: deepDiff_differenceExp
+            connections.scoreExposure: deepDiff_scoreExp
+            connections.warpedExposure: deepDiff_warpedExp
+            connections.matchedExposure: deepDiff_matchedExp
+            connections.diaSources: deepDiff_diaSrc
+            # TODO: end DM-30210 workaround
     imageDifference:
         class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
         config:
@@ -52,6 +74,7 @@ tasks:
             connections.diffIm: fakes_deepDiff_differenceExp
             connections.diaSourceTable: fakes_deepDiff_diaSrcTable
             # TODO: end DM-30210 workaround
+    # Can't have separate with- and without-fakes runs for diaPipe, because there's only one APDB
     diaPipe:
         class: lsst.ap.association.DiaPipelineTask
         config:


### PR DESCRIPTION
This PR updates the `ApVerifyWithFakes` pipeline so that all metrics in `ip_diffim` and `pipe_tasks` can be expressed in terms of fakes-free datasets. This required some hacking to work around the default AP pipeline's assumptions about which tasks depended on which.