### PR TITLE
DM-31801: Use lsst prefix for loggers

### DIFF
--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -41,6 +41,8 @@ from .metrics import MetricsParser, computeMetrics
 from .pipeline_driver import ApPipeParser, runApPipeGen2, runApPipeGen3
 from .workspace import WorkspaceGen2, WorkspaceGen3
 
+_LOG = lsst.log.Log.getLogger(__name__)
+
 
 class _InputOutputParser(argparse.ArgumentParser):
     """An argument parser for program-wide input and output.
@@ -188,7 +190,7 @@ def runApVerify(cmdLine=None):
         or 127 if the task runner framework failed.
     """
     lsst.log.configure()
-    log = lsst.log.Log.getLogger('ap.verify.ap_verify.main')
+    log = _LOG.getChild('main')
     # TODO: what is LSST's policy on exceptions escaping into main()?
     args = _ApVerifyParser().parse_args(args=cmdLine)
     log.debug('Command-line arguments: %s', args)
@@ -245,7 +247,7 @@ def runIngestion(cmdLine=None):
         Python code. If `None`, `sys.argv` will be used.
     """
     lsst.log.configure()
-    log = lsst.log.Log.getLogger('ap.verify.ap_verify.ingest')
+    log = _LOG.getChild('ingest')
     # TODO: what is LSST's policy on exceptions escaping into main()?
     args = _IngestOnlyParser().parse_args(args=cmdLine)
     log.debug('Command-line arguments: %s', args)

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -32,6 +32,8 @@ __all__ = ["runApVerify", "runIngestion"]
 import argparse
 import re
 import warnings
+import sys
+import logging
 
 import lsst.log
 
@@ -41,7 +43,17 @@ from .metrics import MetricsParser, computeMetrics
 from .pipeline_driver import ApPipeParser, runApPipeGen2, runApPipeGen3
 from .workspace import WorkspaceGen2, WorkspaceGen3
 
-_LOG = lsst.log.Log.getLogger(__name__)
+_LOG = logging.getLogger(__name__)
+
+
+def _configure_logger():
+    """Configure Python logging.
+
+    Does basic Python logging configuration and
+    forwards LSST logger to Python logging.
+    """
+    logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+    lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
 
 
 class _InputOutputParser(argparse.ArgumentParser):
@@ -189,7 +201,7 @@ def runApVerify(cmdLine=None):
         The number of data IDs that were not successfully processed, up to 127,
         or 127 if the task runner framework failed.
     """
-    lsst.log.configure()
+    _configure_logger()
     log = _LOG.getChild('main')
     # TODO: what is LSST's policy on exceptions escaping into main()?
     args = _ApVerifyParser().parse_args(args=cmdLine)
@@ -246,7 +258,7 @@ def runIngestion(cmdLine=None):
         an optional command line used to execute `runIngestion` from other
         Python code. If `None`, `sys.argv` will be used.
     """
-    lsst.log.configure()
+    _configure_logger()
     log = _LOG.getChild('ingest')
     # TODO: what is LSST's policy on exceptions escaping into main()?
     args = _IngestOnlyParser().parse_args(args=cmdLine)

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -48,6 +48,8 @@ from lsst.pipe.tasks.ingest import IngestTask
 from lsst.pipe.tasks.ingestCalibs import IngestCalibsTask
 from lsst.pipe.tasks.ingestCuratedCalibs import IngestCuratedCalibsTask
 
+_LOG = lsst.log.Log.getLogger(__name__)
+
 
 class DatasetIngestConfig(pexConfig.Config):
     """Settings and defaults for `DatasetIngestTask`.
@@ -615,7 +617,7 @@ def ingestDataset(dataset, workspace):
         ``obs`` package).
     """
     # TODO: generalize to support arbitrary URIs (DM-11482)
-    log = lsst.log.Log.getLogger("ap.verify.ingestion.ingestDataset")
+    log = _LOG.getChild("ingestDataset")
 
     ingester = DatasetIngestTask(config=_getConfig(DatasetIngestTask, dataset))
     ingester.run(dataset, workspace)
@@ -637,7 +639,7 @@ def ingestDatasetGen3(dataset, workspace, processes=1):
     processes : `int`
         The number processes to use to ingest.
     """
-    log = lsst.log.Log.getLogger("ap.verify.ingestion.ingestDataset")
+    log = _LOG.getChild("ingestDataset")
 
     ingester = Gen3DatasetIngestTask(dataset, workspace, config=_getConfig(Gen3DatasetIngestTask, dataset))
     ingester.run(processes=processes)

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -36,9 +36,9 @@ import shutil
 import tarfile
 from glob import glob
 import sqlite3
+import logging
 
 import lsst.utils
-import lsst.log
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 
@@ -48,7 +48,7 @@ from lsst.pipe.tasks.ingest import IngestTask
 from lsst.pipe.tasks.ingestCalibs import IngestCalibsTask
 from lsst.pipe.tasks.ingestCuratedCalibs import IngestCuratedCalibsTask
 
-_LOG = lsst.log.Log.getLogger(__name__)
+_LOG = logging.getLogger(__name__)
 
 
 class DatasetIngestConfig(pexConfig.Config):

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -33,15 +33,15 @@ import argparse
 import os
 import re
 import subprocess
+import logging
 
-import lsst.log
 import lsst.pipe.base as pipeBase
 import lsst.ctrl.mpexec.execFixupDataId  # not part of lsst.ctrl.mpexec
 import lsst.ctrl.mpexec.cli.pipetask
 import lsst.ap.pipe as apPipe
 from lsst.ap.pipe.make_apdb import makeApdb
 
-_LOG = lsst.log.Log.getLogger(__name__)
+_LOG = logging.getLogger(__name__)
 
 
 class ApPipeParser(argparse.ArgumentParser):

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -41,6 +41,8 @@ import lsst.ctrl.mpexec.cli.pipetask
 import lsst.ap.pipe as apPipe
 from lsst.ap.pipe.make_apdb import makeApdb
 
+_LOG = lsst.log.Log.getLogger(__name__)
+
 
 class ApPipeParser(argparse.ArgumentParser):
     """An argument parser for data needed by ``ap_pipe`` activities.
@@ -105,7 +107,7 @@ def runApPipeGen2(workspace, parsedCmdLine, processes=1):
         ``doReturnResults=False``. This object is valid even if
         `~lsst.ap.pipe.ApPipeTask` was never run.
     """
-    log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipeGen2')
+    log = _LOG.getChild('runApPipeGen2')
 
     makeApdb(_getApdbArguments(workspace, parsedCmdLine))
 
@@ -158,7 +160,7 @@ def runApPipeGen3(workspace, parsedCmdLine, processes=1):
         nonzero if there were errors. The exact meaning of nonzereo values
         is an implementation detail.
     """
-    log = lsst.log.Log.getLogger('ap.verify.pipeline_driver.runApPipeGen3')
+    log = _LOG.getChild('runApPipeGen3')
 
     makeApdb(_getApdbArguments(workspace, parsedCmdLine))
 


### PR DESCRIPTION
I think in order to switch to python logging we'll have to add a logging.basicConfig and lsst.log forwarding in here somewhere.