### PR TITLE
DM-27117: Add dummy pipeline to ap_verify testing

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,2 +1,2 @@
-Copyright 2017-2021 University of Washington
+Copyright 2017-2022 University of Washington
 Copyright 2020 The Trustees of Princeton University

--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -38,6 +38,7 @@ from lsst.pipe.base import PipelineTask, Struct
 from lsst.ip.isr import IsrTaskConfig
 from lsst.pipe.tasks.characterizeImage import CharacterizeImageConfig
 from lsst.pipe.tasks.calibrate import CalibrateConfig
+from lsst.pipe.tasks.imageDifference import ImageDifferenceConfig
 
 
 class MockIsrTask(PipelineTask):
@@ -265,3 +266,83 @@ class MockCalibrateTask(PipelineTask):
                       outputCat=afwTable.SourceCatalog(),
                       astromMatches=[],
                       )
+
+
+class MockImageDifferenceTask(PipelineTask):
+    """A do-nothing substitute for ImageDifferenceTask.
+    """
+    ConfigClass = ImageDifferenceConfig
+    _DefaultName = "notImageDifference"
+
+    def __init__(self, butler=None, **kwargs):
+        super().__init__(**kwargs)
+        self.outputSchema = afwTable.SourceCatalog()
+
+    def runQuantum(self, butlerQC, inputRefs, outputRefs):
+        inputs = butlerQC.get(inputRefs)
+        outputs = self.run(exposure=inputs['exposure'],
+                           templateExposure=afwImage.ExposureF(),
+                           idFactory=obsBase.ExposureIdInfo(8, 4).makeSourceIdFactory())
+        butlerQC.put(outputs, outputRefs)
+
+    def run(self, exposure=None, selectSources=None, templateExposure=None, templateSources=None,
+            idFactory=None, calexpBackgroundExposure=None, subtractedExposure=None):
+        """Produce differencing outputs with no processing.
+
+        Parameters
+        ----------
+        exposure : `lsst.afw.image.ExposureF`, optional
+            The science exposure, the minuend in the image subtraction.
+            Can be None only if ``config.doSubtract==False``.
+        selectSources : `lsst.afw.table.SourceCatalog`, optional
+            Identified sources on the science exposure. This catalog is used to
+            select sources in order to perform the AL PSF matching on stamp images
+            around them. The selection steps depend on config options and whether
+            ``templateSources`` and ``matchingSources`` specified.
+        templateExposure : `lsst.afw.image.ExposureF`, optional
+            The template to be subtracted from ``exposure`` in the image subtraction.
+            ``templateExposure`` is modified in place if ``config.doScaleTemplateVariance==True``.
+            The template exposure should cover the same sky area as the science exposure.
+            It is either a stich of patches of a coadd skymap image or a calexp
+            of the same pointing as the science exposure. Can be None only
+            if ``config.doSubtract==False`` and ``subtractedExposure`` is not None.
+        templateSources : `lsst.afw.table.SourceCatalog`, optional
+            Identified sources on the template exposure.
+        idFactory : `lsst.afw.table.IdFactory`
+            Generator object to assign ids to detected sources in the difference image.
+        calexpBackgroundExposure : `lsst.afw.image.ExposureF`, optional
+            Background exposure to be added back to the science exposure
+            if ``config.doAddCalexpBackground==True``
+        subtractedExposure : `lsst.afw.image.ExposureF`, optional
+            If ``config.doSubtract==False`` and ``config.doDetection==True``,
+            performs the post subtraction source detection only on this exposure.
+            Otherwise should be None.
+
+        Returns
+        -------
+        results : `lsst.pipe.base.Struct`
+
+            ``subtractedExposure`` : `lsst.afw.image.ExposureF`
+                Difference image.
+            ``scoreExposure`` : `lsst.afw.image.ExposureF` or `None`
+                The zogy score exposure, if calculated.
+            ``matchedExposure`` : `lsst.afw.image.ExposureF`
+                The matched PSF exposure.
+            ``warpedExposure`` : `lsst.afw.image.ExposureF`
+                The warped PSF exposure.
+            ``subtractRes`` : `lsst.pipe.base.Struct`
+                The returned result structure of the ImagePsfMatchTask subtask.
+            ``diaSources``  : `lsst.afw.table.SourceCatalog`
+                The catalog of detected sources.
+            ``selectSources`` : `lsst.afw.table.SourceCatalog`
+                The input source catalog with optionally added Qa information.
+        """
+        return Struct(
+            subtractedExposure=afwImage.ExposureF(),
+            scoreExposure=afwImage.ExposureF(),
+            warpedExposure=afwImage.ExposureF(),
+            matchedExposure=afwImage.ExposureF(),
+            subtractRes=Struct(),
+            diaSources=afwTable.SourceCatalog(),
+            selectSources=afwTable.SourceCatalog(),
+        )

--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -1,0 +1,134 @@
+#
+# This file is part of ap_verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+# These classes exist only to be included in a mock pipeline, and don't need
+# to be public for that.
+__all__ = []
+
+
+import numpy as np
+
+import lsst.afw.image as afwImage
+from lsst.pipe.base import PipelineTask, Struct
+from lsst.ip.isr import IsrTaskConfig
+
+
+class MockIsrTask(PipelineTask):
+    """A do-nothing substitute for IsrTask.
+    """
+    ConfigClass = IsrTaskConfig
+    _DefaultName = "notIsr"
+
+    def run(self, ccdExposure, *, camera=None, bias=None, linearizer=None,
+            crosstalk=None, crosstalkSources=None,
+            dark=None, flat=None, ptc=None, bfKernel=None, bfGains=None, defects=None,
+            fringes=Struct(fringes=None), opticsTransmission=None, filterTransmission=None,
+            sensorTransmission=None, atmosphereTransmission=None,
+            detectorNum=None, strayLightData=None, illumMaskedImage=None,
+            isGen3=False,
+            ):
+        """Accept ISR inputs, and produce ISR outputs with no processing.
+
+        Parameters
+        ----------
+        ccdExposure : `lsst.afw.image.Exposure`
+            The raw exposure that is to be run through ISR.  The
+            exposure is modified by this method.
+        camera : `lsst.afw.cameraGeom.Camera`, optional
+            The camera geometry for this exposure. Required if
+            one or more of ``ccdExposure``, ``bias``, ``dark``, or
+            ``flat`` does not have an associated detector.
+        bias : `lsst.afw.image.Exposure`, optional
+            Bias calibration frame.
+        linearizer : `lsst.ip.isr.linearize.LinearizeBase`, optional
+            Functor for linearization.
+        crosstalk : `lsst.ip.isr.crosstalk.CrosstalkCalib`, optional
+            Calibration for crosstalk.
+        crosstalkSources : `list`, optional
+            List of possible crosstalk sources.
+        dark : `lsst.afw.image.Exposure`, optional
+            Dark calibration frame.
+        flat : `lsst.afw.image.Exposure`, optional
+            Flat calibration frame.
+        ptc : `lsst.ip.isr.PhotonTransferCurveDataset`, optional
+            Photon transfer curve dataset, with, e.g., gains
+            and read noise.
+        bfKernel : `numpy.ndarray`, optional
+            Brighter-fatter kernel.
+        bfGains : `dict` of `float`, optional
+            Gains used to override the detector's nominal gains for the
+            brighter-fatter correction. A dict keyed by amplifier name for
+            the detector in question.
+        defects : `lsst.ip.isr.Defects`, optional
+            List of defects.
+        fringes : `lsst.pipe.base.Struct`, optional
+            Struct containing the fringe correction data, with
+            elements:
+            - ``fringes``: fringe calibration frame (`afw.image.Exposure`)
+            - ``seed``: random seed derived from the ccdExposureId for random
+                number generator (`uint32`)
+        opticsTransmission: `lsst.afw.image.TransmissionCurve`, optional
+            A ``TransmissionCurve`` that represents the throughput of the
+            optics, to be evaluated in focal-plane coordinates.
+        filterTransmission : `lsst.afw.image.TransmissionCurve`
+            A ``TransmissionCurve`` that represents the throughput of the
+            filter itself, to be evaluated in focal-plane coordinates.
+        sensorTransmission : `lsst.afw.image.TransmissionCurve`
+            A ``TransmissionCurve`` that represents the throughput of the
+            sensor itself, to be evaluated in post-assembly trimmed detector
+            coordinates.
+        atmosphereTransmission : `lsst.afw.image.TransmissionCurve`
+            A ``TransmissionCurve`` that represents the throughput of the
+            atmosphere, assumed to be spatially constant.
+        detectorNum : `int`, optional
+            The integer number for the detector to process.
+        isGen3 : bool, optional
+            Flag this call to run() as using the Gen3 butler environment.
+        strayLightData : `object`, optional
+            Opaque object containing calibration information for stray-light
+            correction.  If `None`, no correction will be performed.
+        illumMaskedImage : `lsst.afw.image.MaskedImage`, optional
+            Illumination correction image.
+
+        Returns
+        -------
+        result : `lsst.pipe.base.Struct`
+            Result struct with components:
+
+            ``exposure``
+                The fully ISR corrected exposure (`afw.image.Exposure`).
+            ``outputExposure``
+                An alias for ``exposure`` (`afw.image.Exposure`).
+            ``ossThumb``
+                Thumbnail image of the exposure after overscan subtraction
+                (`numpy.ndarray`).
+            ``flattenedThumb``
+                Thumbnail image of the exposure after flat-field correction
+                (`numpy.ndarray`).
+        """
+        return Struct(exposure=afwImage.ExposureF(),
+                      outputExposure=afwImage.ExposureF(),
+                      ossThumb=np.empty((1, 1)),
+                      flattenedThumb=np.empty((1, 1)),
+                      )

--- a/tests/MockApPipe.yaml
+++ b/tests/MockApPipe.yaml
@@ -1,0 +1,90 @@
+description: Mock Alert Production pipeline. Use only for testing!
+
+parameters:
+  # only templates in ap_verify_testdata
+  coaddName: goodSeeing
+  # only refcat in ap_verify_testdata
+  refcat: gaia
+  # TODO: redundant connection definitions workaround for DM-30210
+  template: goodSeeingCoadd
+  diaSrcCat: goodSeeingDiff_diaSrc
+  diaSrcSchema: goodSeeingDiff_diaSrc_schema
+  diaSrcParquet: goodSeeingDiff_diaSrcTable
+  diff: goodSeeingDiff_differenceExp
+  diffScore: goodSeeingDiff_scoreExp
+  diffWarp: goodSeeingDiff_warpedExp
+  diffMatch: goodSeeingDiff_matchedExp
+  assocSrc: goodSeeingDiff_assocDiaSrc
+  # TODO: end DM-30210 workaround
+tasks:
+  isr:
+    class: lsst.ap.verify.testPipeline.MockIsrTask
+    config:
+      # ap_verify_testdata lacks many auxiliary inputs
+      doDark: False
+      doDefect: False
+  characterizeImage: lsst.ap.verify.testPipeline.MockCharacterizeImageTask
+  calibrate:
+    class: lsst.ap.verify.testPipeline.MockCalibrateTask
+    config:
+      connections.astromRefCat: parameters.refcat
+      connections.photoRefCat: parameters.refcat
+      # Backwards-compatibility with Gen 2
+      astromRefObjLoader.ref_dataset_name: parameters.refcat
+      photoRefObjLoader.ref_dataset_name: parameters.refcat
+      # ap_verify_testdata has bad refcats
+      doAstrometry: False
+      doPhotoCal: False
+  imageDifference:
+    class: lsst.ap.verify.testPipeline.MockImageDifferenceTask
+    config:
+      doWriteWarpedExp: True             # Required for packaging alerts in diaPipe
+      doSkySources: True
+      coaddName: parameters.coaddName              # Can be removed once ImageDifference no longer supports Gen 2
+      getTemplate.coaddName: parameters.coaddName  # Can be removed once ImageDifference no longer supports Gen 2
+      connections.coaddName: parameters.coaddName
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.coaddExposures: parameters.template
+      connections.dcrCoadds: dcrCoadd
+      connections.outputSchema: parameters.diaSrcSchema
+      connections.subtractedExposure: parameters.diff
+      connections.scoreExposure: parameters.diffScore
+      connections.warpedExposure: parameters.diffWarp
+      connections.matchedExposure: parameters.diffMatch
+      connections.diaSources: parameters.diaSrcCat
+      # TODO: end DM-30210 workaround
+  transformDiaSrcCat:
+    class: lsst.ap.verify.testPipeline.MockTransformDiaSourceCatalogTask
+    config:
+      doRemoveSkySources: True
+      connections.coaddName: parameters.coaddName
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.diaSourceSchema: parameters.diaSrcSchema
+      connections.diaSourceCat: parameters.diaSrcCat
+      connections.diffIm: parameters.diff
+      connections.diaSourceTable: parameters.diaSrcParquet
+      # TODO: end DM-30210 workaround
+  diaPipe:
+    class: lsst.ap.verify.testPipeline.MockDiaPipelineTask
+    config:
+      doWriteAssociatedSources: True
+      connections.coaddName: parameters.coaddName
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.diaSourceTable: parameters.diaSrcParquet
+      connections.diffIm: parameters.diff
+      connections.warpedExposure: parameters.diffWarp
+      connections.associatedDiaSources: parameters.assocSrc
+      # TODO: end DM-30210 workaround
+contracts:
+  # DiaPipelineTask needs diaSource fluxes, catalogs, warped exposures, and difference exposures
+  - imageDifference.doMeasurement is True
+  - imageDifference.doWriteSources is True
+  - imageDifference.doWriteWarpedExp is True
+  - imageDifference.doWriteSubtractedExp is True
+  - imageDifference.doSkySources == transformDiaSrcCat.doRemoveSkySources
+  # Inputs and outputs must match
+  - imageDifference.connections.coaddName == transformDiaSrcCat.connections.coaddName
+  - imageDifference.connections.fakesType == transformDiaSrcCat.connections.fakesType
+  - imageDifference.connections.coaddName == diaPipe.connections.coaddName
+  - imageDifference.connections.fakesType == diaPipe.connections.fakesType
+  - transformDiaSrcCat.connections.diaSourceTable == diaPipe.connections.diaSourceTable

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -170,15 +170,20 @@ class PipelineDriverTestSuiteGen3(DataTestCase):
         apdbConfig = self.workspace.analysisButler.get("apdb_marker", id)
         self.assertEqual(apdbConfig.db_url, self.apPipeArgs.db)
 
-    @unittest.skip("Fix test in DM-27117")
-    @patchApPipeGen3
-    def testrunApPipeGen3Reuse(self, _mockDb, mockFwk):
+    def testrunApPipeGen3Reuse(self):
         """Test that runApPipeGen3 does not run the pipeline at all (not even with
         --skip-existing) if --skip-pipeline is provided.
         """
         skipArgs = pipeline_driver.ApPipeParser().parse_args(["--skip-pipeline"])
         pipeline_driver.runApPipeGen3(self.workspace, skipArgs)
-        mockFwk().parseAndRun.assert_not_called()
+
+        # Use datasets as a proxy for pipeline completion.
+        # Depending on the overall test setup, the dataset may or may not be
+        # registered if the pipeline didn't run; check both cases.
+        id = _getDataIds(self.workspace.analysisButler)[0]
+        calexpQuery = set(self.workspace.analysisButler.registry.queryDatasetTypes("calexp"))
+        calexpExists = len(calexpQuery) > 0
+        self.assertFalse(calexpExists and self.workspace.analysisButler.datasetExists("calexp", id))
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -26,7 +26,7 @@ import pickle
 import re
 import shutil
 import tempfile
-import unittest.mock
+import unittest
 
 import lsst.utils.tests
 from lsst.daf.butler import CollectionType

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -34,7 +34,7 @@ import lsst.skymap
 import lsst.daf.butler.tests as butlerTests
 import lsst.pipe.base.testUtils as pipelineTests
 from lsst.ap.verify.testPipeline import MockIsrTask, MockCharacterizeImageTask, \
-    MockCalibrateTask, MockImageDifferenceTask
+    MockCalibrateTask, MockImageDifferenceTask, MockTransformDiaSourceCatalogTask
 
 
 class MockTaskTestSuite(unittest.TestCase):
@@ -108,6 +108,7 @@ class MockTaskTestSuite(unittest.TestCase):
         butlerTests.addDatasetType(cls.repo, "deepDiff_warpedExp", cls.visitId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_matchedExp", cls.visitId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_diaSrc", cls.visitId.keys(), "SourceCatalog")
+        butlerTests.addDatasetType(cls.repo, "deepDiff_diaSrcTable", cls.visitId.keys(), "DataFrame")
 
     def setUp(self):
         super().setUp()
@@ -188,6 +189,22 @@ class MockTaskTestSuite(unittest.TestCase):
              "warpedExposure": self.visitId,
              "matchedExposure": self.visitId,
              "diaSources": self.visitId,
+             })
+        pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
+
+    def testMockTransformDiaSourceCatalogTask(self):
+        task = MockTransformDiaSourceCatalogTask(initInputs=afwTable.SourceCatalog())
+        pipelineTests.assertValidInitOutput(task)
+        result = task.run(afwTable.SourceCatalog(), afwImage.ExposureF(), 'k', 42)
+        pipelineTests.assertValidOutput(task, result)
+
+        self.butler.put(afwTable.SourceCatalog(), "deepDiff_diaSrc", self.visitId)
+        self.butler.put(afwImage.ExposureF(), "deepDiff_differenceExp", self.visitId)
+        quantum = pipelineTests.makeQuantum(
+            task, self.butler, self.visitId,
+            {"diaSourceCat": self.visitId,
+             "diffIm": self.visitId,
+             "diaSourceTable": self.visitId,
              })
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -1,0 +1,63 @@
+#
+# This file is part of ap_verify.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import unittest
+
+import lsst.utils.tests
+import lsst.afw.image as afwImage
+import lsst.pipe.base.testUtils as pipelineTests
+from lsst.ap.verify.testPipeline import MockIsrTask
+
+
+class MockTaskTestSuite(unittest.TestCase):
+    """Test that mock tasks have the correct inputs and outputs for the task
+    they are replacing.
+
+    These tests assume that the mock tasks use real config and connection
+    classes, and therefore out-of-date mocks won't match their connections.
+    """
+
+    def testMockIsr(self):
+        # Testing MockIsrTask is tricky because the real ISR has an unstable
+        # interface with dozens of potential inputs, too many to pass through
+        # runTestQuantum. I don't see a good way to test the inputs;
+        # fortunately, this is unlikely to matter for the overall goal of
+        # testing ap_verify's interaction with the AP pipeline.
+        task = MockIsrTask()
+        pipelineTests.assertValidInitOutput(task)
+        # Skip runTestQuantum
+        result = task.run(afwImage.ExposureF())
+        pipelineTests.assertValidOutput(task, result)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR adds a dummy pipeline that mirrors the form, configuration, and connections of `${AP_PIPE_DIR}/pipelines/ApPipe.yaml`, but is specialized for `ap_verify_testdata` and does no processing besides dataset handling. It then rewrites the tests in `test_driver.py` to make use of the new pipeline.

This change pushes the total unit test run time up to a minute (30 s per individual test), but I don't see any way to reduce this time at present. Because the repository setup for `ap_verify` is fairly complex and doesn't allow for customization hooks, creating an in-memory repository is not practical. I did try to factor the repository setup into `setUpClass`, but this actually _increased_ test run time.

In any case, 20 s of each test's 30 s run time is from running the pipeline itself; this will be addressed on [DM-33734](https://jira.lsstcorp.org/browse/DM-33734) since it has implications for Production.