### PR TITLE
DM-33783: Don't try to parallelize visit definition.

### DIFF
--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -211,7 +211,7 @@ class Gen3DatasetIngestTask(pipeBase.Task):
         exposuresNoVisits = exposures - exposuresWithVisits
         if exposuresNoVisits:
             self.log.info("Defining visits...")
-            self.visitDefiner.run(exposuresNoVisits, processes=processes)
+            self.visitDefiner.run(exposuresNoVisits)
         else:
             self.log.info("Visits were previously defined, skipping...")
 


### PR DESCRIPTION
This leaves a few unused function arguments in place to reduce the potential for breakage.