### PR TITLE
DM-32694: Split AP pipeline into ApPipeWithFakes

### DIFF
--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -13,5 +13,6 @@ tasks:
       doPackageAlerts: True
 contracts:
   # Metric inputs must match pipeline outputs
-  - imageDifference.connections.coaddName == fracDiaSourcesToSciSources.connections.coaddName
-  - imageDifference.connections.fakesType == fracDiaSourcesToSciSources.connections.fakesType
+  # Use of ConnectionsClass for templated fields is a workaround for DM-30210
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).diaSources.name ==
+      fracDiaSourcesToSciSources.connections.ConnectionsClass(config=fracDiaSourcesToSciSources).diaSources.name

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -3,9 +3,9 @@
 
 description: Fully instrumented AP pipeline with fakes
 imports:
-  - location: $AP_VERIFY_DIR/pipelines/ApVerify.yaml
-    exclude:
-      - fracDiaSourcesToSciSources  # Selectively turn off this task's contracts
+  - location: $AP_PIPE_DIR/pipelines/ApPipeWithFakes.yaml
+  - location: $AP_VERIFY_DIR/pipelines/MetricsRuntime.yaml
+  - location: $AP_VERIFY_DIR/pipelines/MetricsMisc.yaml
   - location: $AP_VERIFY_DIR/pipelines/MetricsForFakes.yaml
 parameters:
   fakesType: fakes_
@@ -24,12 +24,16 @@ tasks:
       select_col: "isTemplateSource"
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-  singleFrameWithFakes:
+  processVisitFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
     config:
       connections.fakesType: parameters.fakesType
       insertFakes.doSubSelectSources: True
       insertFakes.select_col: "isVisitSource"
+  retrieveTemplate:
+    class: lsst.ip.diffim.getTemplate.GetTemplateTask
+    config:
+        connections.coaddName: parameters.coaddName
   retrieveTemplateWithFakes:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:
@@ -45,12 +49,12 @@ tasks:
       doSkySources: True
       coaddName: parameters.coaddName
       connections.coaddName: parameters.coaddName
-  imageDifference:
+  imageDifferenceWithFakes:
     class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
     config:
       doWriteWarpedExp: True       # Required for packaging alerts in diaPipe
       connections.fakesType: parameters.fakesType
-  transformDiaSrcCat:
+  transformDiaSrcCatWithFakes:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
       connections.fakesType: parameters.fakesType
@@ -58,9 +62,10 @@ tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
+      doPackageAlerts: True
       doWriteAssociatedSources: True
       connections.fakesType: parameters.fakesType
-  fakesMatcher:
+  fakesMatch:
     class: lsst.pipe.tasks.matchFakes.MatchVariableFakesTask
     config:
       matchDistanceArcseconds: 0.1
@@ -101,6 +106,11 @@ tasks:
     config:
       connections.labelName: imageDifferenceNoFakes
       target: imageDifferenceNoFakes:measurement.run
+  timing_transformDiaSrcCat:
+    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+    config:
+      connections.labelName: transformDiaSrcCatWithFakes
+      target: transformDiaSrcCatWithFakes.run
 subsets:
   apPipe:
     subset:
@@ -120,12 +130,12 @@ subsets:
       Creation of fake sources.
   apPipeWithFakes:
     subset:
-      - singleFrameWithFakes    # characterizeImage and calibrate with fakes
+      - processVisitFakes    # characterizeImage and calibrate with fakes
       - retrieveTemplateWithFakes
-      - imageDifference
-      - transformDiaSrcCat
+      - imageDifferenceWithFakes
+      - transformDiaSrcCatWithFakes
       - diaPipe
-      - fakesMatcher
+      - fakesMatch
     description: >
       The AP pipeline with fakes. Requires apPipe and prepareFakes subsets.
 contracts:
@@ -134,24 +144,24 @@ contracts:
   - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
       coaddFakes.connections.ConnectionsClass(config=coaddFakes).fakeCat.name
   - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
-      singleFrameWithFakes.connections.ConnectionsClass(config=singleFrameWithFakes).fakeCats.name
+      processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).fakeCats.name
   - coaddFakes.connections.ConnectionsClass(config=coaddFakes).imageWithFakes.name ==
       retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).coaddExposures.name
-  - singleFrameWithFakes.connections.ConnectionsClass(config=singleFrameWithFakes).outputExposure.name ==
-      imageDifference.connections.ConnectionsClass(config=imageDifference).exposure.name
+  - processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).outputExposure.name ==
+      imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).exposure.name
   - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
-      fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).fakeCats.name
-  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
-      fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).diffIm.name
+      fakesMatch.connections.ConnectionsClass(config=fakesMatch).fakeCats.name
+  - imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).subtractedExposure.name ==
+      fakesMatch.connections.ConnectionsClass(config=fakesMatch).diffIm.name
   - diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
-      fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).associatedDiaSources.name
+      fakesMatch.connections.ConnectionsClass(config=fakesMatch).associatedDiaSources.name
   - retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).outputExposure.name ==
-      imageDifference.connections.ConnectionsClass(config=imageDifference).inputTemplate.name
-  - fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).matchedDiaSources.name ==
+      imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).inputTemplate.name
+  - fakesMatch.connections.ConnectionsClass(config=fakesMatch).matchedDiaSources.name ==
       apFakesCompletenessMag20t22.connections.ConnectionsClass(config=apFakesCompletenessMag20t22).matchedFakes.name
-  - fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).matchedDiaSources.name ==
+  - fakesMatch.connections.ConnectionsClass(config=fakesMatch).matchedDiaSources.name ==
       apFakesCompletenessMag22t24.connections.ConnectionsClass(config=apFakesCompletenessMag22t24).matchedFakes.name
-  - fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).matchedDiaSources.name ==
+  - fakesMatch.connections.ConnectionsClass(config=fakesMatch).matchedDiaSources.name ==
       apFakesCompletenessMag24t26.connections.ConnectionsClass(config=apFakesCompletenessMag24t26).matchedFakes.name
   - imageDifferenceNoFakes.connections.ConnectionsClass(config=imageDifferenceNoFakes).diaSources.name ==
       fracDiaSourcesToSciSources.connections.ConnectionsClass(config=fracDiaSourcesToSciSources).diaSources.name

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -69,6 +69,8 @@ tasks:
   fracDiaSourcesToSciSources:
     # Uses output of imageDifferenceNoFakes
     class: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask
+    config:
+      connections.coaddName: parameters.coaddName
   timing_imageDifference:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -7,161 +7,46 @@ imports:
   - location: $AP_VERIFY_DIR/pipelines/MetricsRuntime.yaml
   - location: $AP_VERIFY_DIR/pipelines/MetricsMisc.yaml
   - location: $AP_VERIFY_DIR/pipelines/MetricsForFakes.yaml
-parameters:
-  fakesType: fakes_
 tasks:
-  createFakes:
-    class: lsst.ap.pipe.createApFakes.CreateRandomApFakesTask
-    config:
-      magMin: 20
-      magMax: 26
-      fakeDensity: 2000
-      connections.fakesType: parameters.fakesType
-  coaddFakes:
-    class: lsst.pipe.tasks.insertFakes.InsertFakesTask
-    config:
-      doSubSelectSources: True
-      select_col: "isTemplateSource"
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-  processVisitFakes:
-    class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
-    config:
-      connections.fakesType: parameters.fakesType
-      insertFakes.doSubSelectSources: True
-      insertFakes.select_col: "isVisitSource"
+  # Parallel to ApPipe's retrieveTemplateWithFakes, allows non-fakes image differencing.
   retrieveTemplate:
     class: lsst.ip.diffim.getTemplate.GetTemplateTask
     config:
         connections.coaddName: parameters.coaddName
-  retrieveTemplateWithFakes:
-    class: lsst.ip.diffim.getTemplate.GetTemplateTask
-    config:
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-
-  # Contracts require imageDifference, transformDiaSrc, and diaPipe to have matching configs.
-  # Since diaPipe must include fakes (see below), do non-fakes processing with non-standard names.
-  imageDifferenceNoFakes:
+  # Parallel to ApPipe's imageDifferenceWithFakes, allows clean differencing metrics.
+  imageDifference:
     class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
     config:
-      doWriteWarpedExp: True       # Required for packaging alerts in diaPipe
+      doWriteWarpedExp: True       # Required for diaPipe, keep for timing/metrics purposes
       doSkySources: True
       coaddName: parameters.coaddName
       connections.coaddName: parameters.coaddName
-  imageDifferenceWithFakes:
-    class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
-    config:
-      doWriteWarpedExp: True       # Required for packaging alerts in diaPipe
-      connections.fakesType: parameters.fakesType
-  transformDiaSrcCatWithFakes:
-    class: lsst.ap.association.TransformDiaSourceCatalogTask
-    config:
-      connections.fakesType: parameters.fakesType
-  # Can't have separate with- and without-fakes runs for diaPipe, because there's only one APDB
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True
-      doWriteAssociatedSources: True
-      connections.fakesType: parameters.fakesType
-  fakesMatch:
-    class: lsst.pipe.tasks.matchFakes.MatchVariableFakesTask
-    config:
-      matchDistanceArcseconds: 0.1
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType
-  fracDiaSourcesToSciSources:
-    # Uses output of imageDifferenceNoFakes
-    class: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask
-    config:
-      connections.coaddName: parameters.coaddName
-  timing_imageDifference:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.labelName: imageDifferenceNoFakes
-      target: imageDifferenceNoFakes.run
-  timing_imageDifference_astrometer:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.labelName: imageDifferenceNoFakes
-      target: imageDifferenceNoFakes:astrometer.loadAndMatch
-  timing_imageDifference_register:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.labelName: imageDifferenceNoFakes
-      target: imageDifferenceNoFakes:register.run
-  timing_imageDifference_subtract:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.labelName: imageDifferenceNoFakes
-      target: imageDifferenceNoFakes:subtract.subtractExposures
-  timing_imageDifference_detection:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.labelName: imageDifferenceNoFakes
-      target: imageDifferenceNoFakes:detection.run
-  timing_imageDifference_measurement:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.labelName: imageDifferenceNoFakes
-      target: imageDifferenceNoFakes:measurement.run
   timing_transformDiaSrcCat:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
-      connections.labelName: transformDiaSrcCatWithFakes
+      connections.labelName: transformDiaSrcCatWithFakes  # Default is transformDiaSrcCat
       target: transformDiaSrcCatWithFakes.run
 subsets:
   apPipe:
+    # Extend the subset through imageDifference.
     subset:
       - isr
       - characterizeImage
       - calibrate
       - retrieveTemplate
-      - imageDifferenceNoFakes
-    description: >
-      The AP pipeline without fakes. Only includes processing through
-      image differencing.
-  prepareFakes:
-    subset:
-      - createFakes
-      - coaddFakes
-    description: >
-      Creation of fake sources.
-  apPipeWithFakes:
-    subset:
-      - processVisitFakes    # characterizeImage and calibrate with fakes
-      - retrieveTemplateWithFakes
-      - imageDifferenceWithFakes
-      - transformDiaSrcCatWithFakes
-      - diaPipe
-      - fakesMatch
-    description: >
-      The AP pipeline with fakes. Requires apPipe and prepareFakes subsets.
+      - imageDifference
 contracts:
   # Metric inputs must match pipeline outputs
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
-  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
-      coaddFakes.connections.ConnectionsClass(config=coaddFakes).fakeCat.name
-  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
-      processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).fakeCats.name
-  - coaddFakes.connections.ConnectionsClass(config=coaddFakes).imageWithFakes.name ==
-      retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).coaddExposures.name
-  - processVisitFakes.connections.ConnectionsClass(config=processVisitFakes).outputExposure.name ==
-      imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).exposure.name
-  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
-      fakesMatch.connections.ConnectionsClass(config=fakesMatch).fakeCats.name
-  - imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).subtractedExposure.name ==
-      fakesMatch.connections.ConnectionsClass(config=fakesMatch).diffIm.name
-  - diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
-      fakesMatch.connections.ConnectionsClass(config=fakesMatch).associatedDiaSources.name
-  - retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).outputExposure.name ==
-      imageDifferenceWithFakes.connections.ConnectionsClass(config=imageDifferenceWithFakes).inputTemplate.name
   - fakesMatch.connections.ConnectionsClass(config=fakesMatch).matchedDiaSources.name ==
       apFakesCompletenessMag20t22.connections.ConnectionsClass(config=apFakesCompletenessMag20t22).matchedFakes.name
   - fakesMatch.connections.ConnectionsClass(config=fakesMatch).matchedDiaSources.name ==
       apFakesCompletenessMag22t24.connections.ConnectionsClass(config=apFakesCompletenessMag22t24).matchedFakes.name
   - fakesMatch.connections.ConnectionsClass(config=fakesMatch).matchedDiaSources.name ==
       apFakesCompletenessMag24t26.connections.ConnectionsClass(config=apFakesCompletenessMag24t26).matchedFakes.name
-  - imageDifferenceNoFakes.connections.ConnectionsClass(config=imageDifferenceNoFakes).diaSources.name ==
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).diaSources.name ==
       fracDiaSourcesToSciSources.connections.ConnectionsClass(config=fracDiaSourcesToSciSources).diaSources.name

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -9,21 +9,6 @@ imports:
   - location: $AP_VERIFY_DIR/pipelines/MetricsForFakes.yaml
 parameters:
   fakesType: fakes_
-  # TODO: redundant connection definitions workaround for DM-30210
-  fakesInput: fakes_fakeSourceCat
-  fakesPvi: fakes_calexp
-  fakesTemplate: fakes_goodSeeingCoadd
-  fakesDcrTemplate: fakes_dcrCoadd
-  fakesDiaSrcCat: fakes_goodSeeingDiff_diaSrc
-  fakesDiaSrcSchema: fakes_goodSeeingDiff_diaSrc_schema
-  fakesDiaSrcParquet: fakes_goodSeeingDiff_diaSrcTable
-  fakesDiff: fakes_goodSeeingDiff_differenceExp
-  fakesDiffScore: fakes_goodSeeingDiff_scoreExp
-  fakesDiffWarp: fakes_goodSeeingDiff_warpedExp
-  fakesDiffMatch: fakes_goodSeeingDiff_matchedExp
-  fakesAssocSrc: fakes_goodSeeingDiff_assocDiaSrc
-  fakesMatchedSrc: fakes_goodSeeingDiff_matchDiaSrc
-  # TODO: end DM-30210 workaround
 tasks:
   createFakes:
     class: lsst.ap.pipe.createApFakes.CreateRandomApFakesTask
@@ -32,9 +17,6 @@ tasks:
       magMax: 26
       fakeDensity: 2000
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.fakeCat: parameters.fakesInput
-      # TODO: end DM-30210 workaround
   coaddFakes:
     class: lsst.pipe.tasks.insertFakes.InsertFakesTask
     config:
@@ -42,14 +24,10 @@ tasks:
       select_col: "isTemplateSource"
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.image: parameters.template
-      connections.fakeCat: parameters.fakesInput
-      connections.imageWithFakes: parameters.fakesTemplate
-      # TODO: end DM-30210 workaround
   singleFrameWithFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
     config:
+      connections.fakesType: parameters.fakesType
       insertFakes.doSubSelectSources: True
       insertFakes.select_col: "isVisitSource"
   retrieveTemplateWithFakes:
@@ -67,71 +45,27 @@ tasks:
       doSkySources: True
       coaddName: parameters.coaddName
       connections.coaddName: parameters.coaddName
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.coaddExposures: parameters.template
-      connections.dcrCoadds: dcrCoadd
-      connections.outputSchema: parameters.diaSrcSchema
-      connections.subtractedExposure: parameters.diff
-      connections.scoreExposure: parameters.diffScore
-      connections.warpedExposure: parameters.diffWarp
-      connections.matchedExposure: parameters.diffMatch
-      connections.diaSources: parameters.diaSrcCat
-      connections.inputTemplate: parameters.templateExp
-      # TODO: end DM-30210 workaround
   imageDifference:
     class: lsst.pipe.tasks.imageDifference.ImageDifferenceFromTemplateTask
     config:
       doWriteWarpedExp: True       # Required for packaging alerts in diaPipe
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.coaddName: parameters.coaddName
-      connections.exposure: parameters.fakesPvi
-      connections.coaddExposures: parameters.fakesTemplate
-      connections.dcrCoadds: fakesDcrTemplate
-      connections.outputSchema: parameters.fakesDiaSrcSchema
-      connections.subtractedExposure: parameters.fakesDiff
-      connections.scoreExposure: parameters.fakesDiffScore
-      connections.warpedExposure: parameters.fakesDiffWarp
-      connections.matchedExposure: parameters.fakesDiffMatch
-      connections.diaSources: parameters.fakesDiaSrcCat
-      connections.inputTemplate: parameters.templateExp
-      # TODO: end DM-30210 workaround
   transformDiaSrcCat:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.coaddName: parameters.coaddName
-      connections.diaSourceSchema: parameters.fakesDiaSrcSchema
-      connections.diaSourceCat: parameters.fakesDiaSrcCat
-      connections.diffIm: parameters.fakesDiff
-      connections.diaSourceTable: parameters.fakesDiaSrcParquet
-      # TODO: end DM-30210 workaround
   # Can't have separate with- and without-fakes runs for diaPipe, because there's only one APDB
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doWriteAssociatedSources: True
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.coaddName: parameters.coaddName
-      connections.diaSourceTable: parameters.fakesDiaSrcParquet
-      connections.diffIm: parameters.fakesDiff
-      connections.warpedExposure: parameters.fakesDiffWarp
-      connections.associatedDiaSources: parameters.fakesAssocSrc
-      # TODO: end DM-30210 workaround
   fakesMatcher:
     class: lsst.pipe.tasks.matchFakes.MatchVariableFakesTask
     config:
       matchDistanceArcseconds: 0.1
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.fakeCats: parameters.fakesInput
-      connections.diffIm: parameters.fakesDiff
-      connections.associatedDiaSources: parameters.fakesAssocSrc
-      connections.matchedDiaSources: parameters.fakesMatchedSrc
-      # TODO: end DM-30210 workaround
   fracDiaSourcesToSciSources:
     # Uses output of imageDifferenceNoFakes
     class: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask
@@ -194,20 +128,28 @@ subsets:
       The AP pipeline with fakes. Requires apPipe and prepareFakes subsets.
 contracts:
   # Metric inputs must match pipeline outputs
-  - createFakes.connections.fakesType == coaddFakes.connections.fakesType
-  - createFakes.connections.fakesType == singleFrameWithFakes.connections.fakesType
-  - createFakes.connections.fakesType == imageDifference.connections.fakesType
-  - createFakes.connections.fakesType == diaPipe.connections.fakesType
-  - createFakes.connections.fakesType == fakesMatcher.connections.fakesType
-  - createFakes.connections.fakesType == apFakesCompletenessMag20t22.connections.fakesType
-  - createFakes.connections.fakesType == apFakesCompletenessMag22t24.connections.fakesType
-  - createFakes.connections.fakesType == apFakesCompletenessMag24t26.connections.fakesType
-  - coaddFakes.connections.coaddName == singleFrameWithFakes.connections.coaddName
-  - coaddFakes.connections.coaddName == imageDifference.connections.coaddName
-  - coaddFakes.connections.coaddName == diaPipe.connections.coaddName
-  - coaddFakes.connections.coaddName == fakesMatcher.connections.coaddName
-  - coaddFakes.connections.coaddName == apFakesCompletenessMag20t22.connections.coaddName
-  - coaddFakes.connections.coaddName == apFakesCompletenessMag22t24.connections.coaddName
-  - coaddFakes.connections.coaddName == apFakesCompletenessMag24t26.connections.coaddName
-  - imageDifferenceNoFakes.connections.coaddName == fracDiaSourcesToSciSources.connections.coaddName
-  - imageDifferenceNoFakes.connections.fakesType == fracDiaSourcesToSciSources.connections.fakesType
+  # Use of ConnectionsClass for templated fields is a workaround for DM-30210
+  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
+      coaddFakes.connections.ConnectionsClass(config=coaddFakes).fakeCat.name
+  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
+      singleFrameWithFakes.connections.ConnectionsClass(config=singleFrameWithFakes).fakeCats.name
+  - coaddFakes.connections.ConnectionsClass(config=coaddFakes).imageWithFakes.name ==
+      retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).coaddExposures.name
+  - singleFrameWithFakes.connections.ConnectionsClass(config=singleFrameWithFakes).outputExposure.name ==
+      imageDifference.connections.ConnectionsClass(config=imageDifference).exposure.name
+  - createFakes.connections.ConnectionsClass(config=createFakes).fakeCat.name ==
+      fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).fakeCats.name
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
+      fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).diffIm.name
+  - diaPipe.connections.ConnectionsClass(config=diaPipe).associatedDiaSources.name ==
+      fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).associatedDiaSources.name
+  - retrieveTemplateWithFakes.connections.ConnectionsClass(config=retrieveTemplateWithFakes).outputExposure.name ==
+      imageDifference.connections.ConnectionsClass(config=imageDifference).inputTemplate.name
+  - fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).matchedDiaSources.name ==
+      apFakesCompletenessMag20t22.connections.ConnectionsClass(config=apFakesCompletenessMag20t22).matchedFakes.name
+  - fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).matchedDiaSources.name ==
+      apFakesCompletenessMag22t24.connections.ConnectionsClass(config=apFakesCompletenessMag22t24).matchedFakes.name
+  - fakesMatcher.connections.ConnectionsClass(config=fakesMatcher).matchedDiaSources.name ==
+      apFakesCompletenessMag24t26.connections.ConnectionsClass(config=apFakesCompletenessMag24t26).matchedFakes.name
+  - imageDifferenceNoFakes.connections.ConnectionsClass(config=imageDifferenceNoFakes).diaSources.name ==
+      fracDiaSourcesToSciSources.connections.ConnectionsClass(config=fracDiaSourcesToSciSources).diaSources.name

--- a/pipelines/DarkEnergyCamera/ApVerify.yaml
+++ b/pipelines/DarkEnergyCamera/ApVerify.yaml
@@ -18,5 +18,6 @@ tasks:
 contracts:
   # Must re-declare contracts that cross apPipe and metrics boundary, as
   # these were removed on import.
-  - imageDifference.connections.coaddName == fracDiaSourcesToSciSources.connections.coaddName
-  - imageDifference.connections.fakesType == fracDiaSourcesToSciSources.connections.fakesType
+  # Use of ConnectionsClass for templated fields is a workaround for DM-30210
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).diaSources.name ==
+      fracDiaSourcesToSciSources.connections.ConnectionsClass(config=fracDiaSourcesToSciSources).diaSources.name

--- a/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
+++ b/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
@@ -24,7 +24,7 @@ tasks:
     config:
       photoCal.match.referenceSelection.magLimit.fluxField: i_flux
       photoCal.match.referenceSelection.magLimit.maximum: 22.0
-  singleFrameWithFakes:
+  processVisitFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
     config:
       calibrate.photoCal.match.referenceSelection.magLimit.fluxField: i_flux

--- a/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
+++ b/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
@@ -8,24 +8,16 @@ instrument: lsst.obs.decam.DarkEnergyCamera
 description: Fully instrumented AP pipeline with fakes, specialized for DECam
 imports:
   - location: $AP_VERIFY_DIR/pipelines/ApVerifyWithFakes.yaml
+    exclude:
+      - processCcd
+  - location: $AP_PIPE_DIR/pipelines/DarkEnergyCamera/ProcessCcd.yaml
   # Can't use $AP_PIPE_DIR/pipelines/DarkEnergyCamera/ApPipeWithFakes.yaml here
   # because the changes made by that file and ../ApVerifyWithFakes.yaml are
   # hard to separate.
 tasks:
-  isr:
-    class: lsst.ip.isr.IsrTask
-    config:
-      connections.ccdExposure: raw
-      connections.crosstalkSources: overscanRaw
-      doOverscan: true
-      doCrosstalk: true
-  calibrate:
-    class: lsst.pipe.tasks.calibrate.CalibrateTask
-    config:
-      photoCal.match.referenceSelection.magLimit.fluxField: i_flux
-      photoCal.match.referenceSelection.magLimit.maximum: 22.0
   processVisitFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
     config:
+      # Mirror calibrate config from DarkEnergyCamera/ProcessCcd.yaml
       calibrate.photoCal.match.referenceSelection.magLimit.fluxField: i_flux
       calibrate.photoCal.match.referenceSelection.magLimit.maximum: 22.0

--- a/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
+++ b/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
@@ -8,9 +8,9 @@ instrument: lsst.obs.decam.DarkEnergyCamera
 description: Fully instrumented AP pipeline with fakes, specialized for DECam
 imports:
   - location: $AP_VERIFY_DIR/pipelines/ApVerifyWithFakes.yaml
-  # Can't use $AP_PIPE_DIR/pipelines/DarkEnergyCamera/ApPipe.yaml here because
-  # ApVerifyWithFakes changes task labels in order to set up parallel fakes
-  # and non-fakes pipelines.
+  # Can't use $AP_PIPE_DIR/pipelines/DarkEnergyCamera/ApPipeWithFakes.yaml here
+  # because the changes made by that file and ../ApVerifyWithFakes.yaml are
+  # hard to separate.
 tasks:
   isr:
     class: lsst.ip.isr.IsrTask

--- a/pipelines/HyperSuprimeCam/ApVerify.yaml
+++ b/pipelines/HyperSuprimeCam/ApVerify.yaml
@@ -18,5 +18,6 @@ tasks:
 contracts:
   # Must re-declare contracts that cross apPipe and metrics boundary, as
   # these were removed on import.
-  - imageDifference.connections.coaddName == fracDiaSourcesToSciSources.connections.coaddName
-  - imageDifference.connections.fakesType == fracDiaSourcesToSciSources.connections.fakesType
+  # Use of ConnectionsClass for templated fields is a workaround for DM-30210
+  - imageDifference.connections.ConnectionsClass(config=imageDifference).diaSources.name ==
+      fracDiaSourcesToSciSources.connections.ConnectionsClass(config=fracDiaSourcesToSciSources).diaSources.name

--- a/pipelines/HyperSuprimeCam/ApVerifyWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApVerifyWithFakes.yaml
@@ -5,6 +5,9 @@ instrument: lsst.obs.subaru.HyperSuprimeCam
 description: Fully instrumented AP pipeline with fakes, specialized for HSC
 imports:
   - location: $AP_VERIFY_DIR/pipelines/ApVerifyWithFakes.yaml
+    exclude:
+      - processCcd
+  - location: $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ProcessCcd.yaml
   # Can't use $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml here
   # because the changes made by that file and ../ApVerifyWithFakes.yaml are
   # hard to separate.

--- a/pipelines/HyperSuprimeCam/ApVerifyWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApVerifyWithFakes.yaml
@@ -5,6 +5,6 @@ instrument: lsst.obs.subaru.HyperSuprimeCam
 description: Fully instrumented AP pipeline with fakes, specialized for HSC
 imports:
   - location: $AP_VERIFY_DIR/pipelines/ApVerifyWithFakes.yaml
-  # Can't use $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ApPipe.yaml here because
-  # ApVerifyWithFakes changes task labels in order to set up parallel fakes
-  # and non-fakes pipelines.
+  # Can't use $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml here
+  # because the changes made by that file and ../ApVerifyWithFakes.yaml are
+  # hard to separate.

--- a/pipelines/MetricsForFakes.yaml
+++ b/pipelines/MetricsForFakes.yaml
@@ -12,9 +12,6 @@ tasks:
       magMax: 22
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.matchedFakes: parameters.fakesMatchedSrc
-      # TODO: end DM-30210 workaround
   apFakesCompletenessMag22t24:
     class: lsst.ap.pipe.metrics.ApFakesCompletenessMetricTask
     config:
@@ -23,9 +20,6 @@ tasks:
       magMax: 24
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.matchedFakes: parameters.fakesMatchedSrc
-      # TODO: end DM-30210 workaround
   apFakesCompletenessMag24t26:
     class: lsst.ap.pipe.metrics.ApFakesCompletenessMetricTask
     config:
@@ -34,9 +28,6 @@ tasks:
       magMax: 26
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.matchedFakes: parameters.fakesMatchedSrc
-      # TODO: end DM-30210 workaround
   apFakesCountMag20t22:
     class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
     config:
@@ -45,9 +36,6 @@ tasks:
       magMax: 22
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.matchedFakes: parameters.fakesMatchedSrc
-      # TODO: end DM-30210 workaround
   apFakesCountMag22t24:
     class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
     config:
@@ -56,9 +44,6 @@ tasks:
       magMax: 24
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.matchedFakes: parameters.fakesMatchedSrc
-      # TODO: end DM-30210 workaround
   apFakesCountMag24t26:
     class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
     config:
@@ -67,9 +52,6 @@ tasks:
       magMax: 26
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.matchedFakes: parameters.fakesMatchedSrc
-      # TODO: end DM-30210 workaround
   apFakesCount:
     class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
     config:
@@ -78,6 +60,3 @@ tasks:
       magMax: 39
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.matchedFakes: parameters.fakesMatchedSrc
-      # TODO: end DM-30210 workaround

--- a/pipelines/MetricsMisc.yaml
+++ b/pipelines/MetricsMisc.yaml
@@ -30,6 +30,8 @@ tasks:
     class: lsst.ip.diffim.metrics.NumberSciSourcesMetricTask
   fracDiaSourcesToSciSources:
     class: lsst.ip.diffim.metrics.FractionDiaSourcesToSciSourcesMetricTask
+    config:
+      connections.coaddName: parameters.coaddName
   numDeblendedSciSources:
     class: lsst.pipe.tasks.metrics.NumberDeblendedSourcesMetricTask
   numDeblendChildSciSources:


### PR DESCRIPTION
This PR refactors the `ApVerifyWithFakes` pipeline to depend on `ApPipeWithFakes` (itself reworked on lsst/ap_pipe#106) instead of `ApVerify`. This change improves consistency with the "base" AP pipeline and avoids some of the contract conflicts that made the previous `ApVerifyWithFakes` more complicated and more brittle than it needed to be.