### PR TITLE
DM-35071: Add support for datasets using old Gen 3 registry versions.

### DIFF
--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -181,8 +181,12 @@ class Gen3DatasetIngestTask(pipeBase.Task):
             raise RuntimeError("No raw files to ingest (expected list of filenames, got %r)." % dataFiles)
 
         try:
-            # run=None because expect ingester to name a new collection
-            self.ingester.run(dataFiles, run=None, processes=processes)
+            # run=None because expect ingester to name a new collection.
+            # HACK: update_exposure_records=True to modernize exposure records
+            # from old ap_verify datasets. Since the exposure records are
+            # generated from the same files, the only changes should be
+            # schema-related.
+            self.ingester.run(dataFiles, run=None, processes=processes, update_exposure_records=True)
         except lsst.daf.butler.registry.ConflictingDefinitionError as detail:
             raise RuntimeError("Not all raw files are unique") from detail
 


### PR DESCRIPTION
This PR allows `ap_verify` to read datasets whose `preloaded` repo has a registry version other than the latest. This solution involves using an unsafe keyword for `RawIngestTask`, but avoids dataset churn.

This fix is not unit tested, since `ap_verify_testdata` does not have solar system data and therefore does not export exposure records.