### PR TITLE
DM-35564: ap_verify docs say datasets should be installed at run-time

### DIFF
--- a/doc/lsst.ap.verify/datasets-install.rst
+++ b/doc/lsst.ap.verify/datasets-install.rst
@@ -36,14 +36,19 @@ For example, to install the `Cosmos PDR2 <https://github.com/lsst/ap_verify_ci_c
 
    rebuild -u ap_verify_ci_cosmos_pdr2
 
-Alternatively, the dataset can be cloned directly and setup:
+Alternatively, the dataset can be cloned directly:
 
 .. prompt:: bash
 
    git clone https://github.com/lsst/ap_verify_ci_cosmos_pdr2/
-   setup -r ap_verify_ci_cosmos_pdr2
 
-The dataset should be setup each time before use.
+Once installed, the dataset must be setup each session before use:
+
+.. prompt:: bash
+
+   setup ap_verify_ci_cosmos_pdr2              # Installed with rebuild
+   setup -r /my/path/ap_verify_ci_cosmos_pdr2  # Installed with git clone
+
 Once this is done, ``ap_verify`` will be able to find the Cosmos data when requested through :option:`--dataset`.
 
 Further reading

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -19,16 +19,16 @@ How to run ap_verify in a new workspace
 
 Using the `Cosmos PDR2`_ CI dataset as an example, one can run :command:`ap_verify.py` as follows.
 
-.. _Cosmos PDR2: https://github.com/lsst/ap_verify_ci_cosmos_pdr2/ 
+.. _Cosmos PDR2: https://github.com/lsst/ap_verify_ci_cosmos_pdr2/
 
-First download and setup the dataset. 
+First download and setup the dataset.
 
 .. prompt:: bash
 
    git clone https://github.com/lsst/ap_verify_ci_cosmos_pdr2/
    setup -r ap_verify_ci_cosmos_pdr2
 
-You will need to setup the dataset each time you want to use it. 
+You will need to setup the dataset each time you want to use it.
 
 .. prompt:: bash
 

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -20,17 +20,17 @@ If this is not the case, see :doc:`datasets-install`.
 How to run ap_verify in a new workspace
 =======================================
 
-Using the `Cosmos PDR2`_ CI dataset as an example, one can run :command:`ap_verify.py` as follows.
+Using the `Cosmos PDR2`_ CI dataset as an example, first setup the dataset, if it isn't already.
 
 .. _Cosmos PDR2: https://github.com/lsst/ap_verify_ci_cosmos_pdr2/
-
-First setup the dataset, if it isn't already.
 
 .. prompt:: bash
 
    setup [-r] ap_verify_ci_cosmos_pdr2
 
 You will need to setup the dataset once each session.
+
+You can then run :command:`ap_verify.py` as follows.
 
 .. prompt:: bash
 

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -12,6 +12,9 @@ Running ap_verify from the command line
 This page describes the most common options used to run ``ap_verify``.
 For more details, see the :doc:`command-line-reference` or run :option:`ap_verify.py -h`.
 
+This guide assumes that the dataset(s) to be run are already installed on the machine.
+If this is not the case, see :doc:`datasets-install`.
+
 .. _ap-verify-run-output-gen3:
 
 How to run ap_verify in a new workspace
@@ -21,14 +24,13 @@ Using the `Cosmos PDR2`_ CI dataset as an example, one can run :command:`ap_veri
 
 .. _Cosmos PDR2: https://github.com/lsst/ap_verify_ci_cosmos_pdr2/
 
-First download and setup the dataset.
+First setup the dataset, if it isn't already.
 
 .. prompt:: bash
 
-   git clone https://github.com/lsst/ap_verify_ci_cosmos_pdr2/
-   setup -r ap_verify_ci_cosmos_pdr2
+   setup [-r] ap_verify_ci_cosmos_pdr2
 
-You will need to setup the dataset each time you want to use it.
+You will need to setup the dataset once each session.
 
 .. prompt:: bash
 


### PR DESCRIPTION
This PR cleans up the docs added in #163 to clearly distinguish between dataset installation, dataset setup, and running `ap_verify`.