### PR TITLE
DM-35721: Create mocks of the new image differencing for ap_verify

### DIFF
--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -55,7 +55,7 @@ class MockIsrTask(PipelineTask):
             fringes=Struct(fringes=None), opticsTransmission=None, filterTransmission=None,
             sensorTransmission=None, atmosphereTransmission=None,
             detectorNum=None, strayLightData=None, illumMaskedImage=None,
-            isGen3=False,
+            deferredCharge=None,
             ):
         """Accept ISR inputs, and produce ISR outputs with no processing.
 
@@ -135,11 +135,17 @@ class MockIsrTask(PipelineTask):
             ``flattenedThumb``
                 Thumbnail image of the exposure after flat-field correction
                 (`numpy.ndarray`).
+            - ``outputStatistics`` : mapping [`str`]
+                Values of the additional statistics calculated.
         """
         return Struct(exposure=afwImage.ExposureF(),
                       outputExposure=afwImage.ExposureF(),
                       ossThumb=np.empty((1, 1)),
                       flattenedThumb=np.empty((1, 1)),
+                      preInterpExposure=afwImage.ExposureF(),
+                      outputOssThumbnail=np.empty((1, 1)),
+                      outputFlattenedThumbnail=np.empty((1, 1)),
+                      outputStatistics={},
                       )
 
 

--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -40,7 +40,6 @@ from lsst.ip.isr import IsrTaskConfig
 from lsst.ip.diffim import GetTemplateConfig, AlardLuptonSubtractConfig, DetectAndMeasureConfig
 from lsst.pipe.tasks.characterizeImage import CharacterizeImageConfig
 from lsst.pipe.tasks.calibrate import CalibrateConfig
-from lsst.pipe.tasks.imageDifference import ImageDifferenceConfig
 from lsst.ap.association import TransformDiaSourceCatalogConfig, DiaPipelineConfig
 
 
@@ -316,86 +315,6 @@ class MockGetTemplateTask(PipelineTask):
         """
         return Struct(template=afwImage.ExposureF(),
                       )
-
-
-class MockImageDifferenceTask(PipelineTask):
-    """A do-nothing substitute for ImageDifferenceTask.
-    """
-    ConfigClass = ImageDifferenceConfig
-    _DefaultName = "notImageDifference"
-
-    def __init__(self, butler=None, **kwargs):
-        super().__init__(**kwargs)
-        self.outputSchema = afwTable.SourceCatalog()
-
-    def runQuantum(self, butlerQC, inputRefs, outputRefs):
-        inputs = butlerQC.get(inputRefs)
-        outputs = self.run(exposure=inputs['exposure'],
-                           templateExposure=afwImage.ExposureF(),
-                           idFactory=obsBase.ExposureIdInfo(8, 4).makeSourceIdFactory())
-        butlerQC.put(outputs, outputRefs)
-
-    def run(self, exposure=None, selectSources=None, templateExposure=None, templateSources=None,
-            idFactory=None, calexpBackgroundExposure=None, subtractedExposure=None):
-        """Produce differencing outputs with no processing.
-
-        Parameters
-        ----------
-        exposure : `lsst.afw.image.ExposureF`, optional
-            The science exposure, the minuend in the image subtraction.
-            Can be None only if ``config.doSubtract==False``.
-        selectSources : `lsst.afw.table.SourceCatalog`, optional
-            Identified sources on the science exposure. This catalog is used to
-            select sources in order to perform the AL PSF matching on stamp images
-            around them. The selection steps depend on config options and whether
-            ``templateSources`` and ``matchingSources`` specified.
-        templateExposure : `lsst.afw.image.ExposureF`, optional
-            The template to be subtracted from ``exposure`` in the image subtraction.
-            ``templateExposure`` is modified in place if ``config.doScaleTemplateVariance==True``.
-            The template exposure should cover the same sky area as the science exposure.
-            It is either a stich of patches of a coadd skymap image or a calexp
-            of the same pointing as the science exposure. Can be None only
-            if ``config.doSubtract==False`` and ``subtractedExposure`` is not None.
-        templateSources : `lsst.afw.table.SourceCatalog`, optional
-            Identified sources on the template exposure.
-        idFactory : `lsst.afw.table.IdFactory`
-            Generator object to assign ids to detected sources in the difference image.
-        calexpBackgroundExposure : `lsst.afw.image.ExposureF`, optional
-            Background exposure to be added back to the science exposure
-            if ``config.doAddCalexpBackground==True``
-        subtractedExposure : `lsst.afw.image.ExposureF`, optional
-            If ``config.doSubtract==False`` and ``config.doDetection==True``,
-            performs the post subtraction source detection only on this exposure.
-            Otherwise should be None.
-
-        Returns
-        -------
-        results : `lsst.pipe.base.Struct`
-
-            ``subtractedExposure`` : `lsst.afw.image.ExposureF`
-                Difference image.
-            ``scoreExposure`` : `lsst.afw.image.ExposureF` or `None`
-                The zogy score exposure, if calculated.
-            ``matchedExposure`` : `lsst.afw.image.ExposureF`
-                The matched PSF exposure.
-            ``warpedExposure`` : `lsst.afw.image.ExposureF`
-                The warped PSF exposure.
-            ``subtractRes`` : `lsst.pipe.base.Struct`
-                The returned result structure of the ImagePsfMatchTask subtask.
-            ``diaSources``  : `lsst.afw.table.SourceCatalog`
-                The catalog of detected sources.
-            ``selectSources`` : `lsst.afw.table.SourceCatalog`
-                The input source catalog with optionally added Qa information.
-        """
-        return Struct(
-            subtractedExposure=afwImage.ExposureF(),
-            scoreExposure=afwImage.ExposureF(),
-            warpedExposure=afwImage.ExposureF(),
-            matchedExposure=afwImage.ExposureF(),
-            subtractRes=Struct(),
-            diaSources=afwTable.SourceCatalog(),
-            selectSources=afwTable.SourceCatalog(),
-        )
 
 
 class MockAlardLuptonSubtractTask(PipelineTask):

--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -37,7 +37,7 @@ import lsst.afw.table as afwTable
 import lsst.obs.base as obsBase
 from lsst.pipe.base import PipelineTask, Struct
 from lsst.ip.isr import IsrTaskConfig
-from lsst.ip.diffim import GetTemplateConfig
+from lsst.ip.diffim import GetTemplateConfig, AlardLuptonSubtractConfig
 from lsst.pipe.tasks.characterizeImage import CharacterizeImageConfig
 from lsst.pipe.tasks.calibrate import CalibrateConfig
 from lsst.pipe.tasks.imageDifference import ImageDifferenceConfig
@@ -396,6 +396,49 @@ class MockImageDifferenceTask(PipelineTask):
             diaSources=afwTable.SourceCatalog(),
             selectSources=afwTable.SourceCatalog(),
         )
+
+
+class MockAlardLuptonSubtractTask(PipelineTask):
+    """A do-nothing substitute for AlardLuptonSubtractTask.
+    """
+    ConfigClass = AlardLuptonSubtractConfig
+    _DefaultName = "notAlardLuptonSubtract"
+
+    def run(self, template, science, sources, finalizedPsfApCorrCatalog=None):
+        """PSF match, subtract, and decorrelate two images.
+
+        Parameters
+        ----------
+        template : `lsst.afw.image.ExposureF`
+            Template exposure, warped to match the science exposure.
+        science : `lsst.afw.image.ExposureF`
+            Science exposure to subtract from the template.
+        sources : `lsst.afw.table.SourceCatalog`
+            Identified sources on the science exposure. This catalog is used to
+            select sources in order to perform the AL PSF matching on stamp
+            images around them.
+        finalizedPsfApCorrCatalog : `lsst.afw.table.ExposureCatalog`, optional
+            Exposure catalog with finalized psf models and aperture correction
+            maps to be applied if config.doApplyFinalizedPsf=True.  Catalog uses
+            the detector id for the catalog id, sorted on id for fast lookup.
+
+        Returns
+        -------
+        results : `lsst.pipe.base.Struct`
+            ``difference`` : `lsst.afw.image.ExposureF`
+                Result of subtracting template and science.
+            ``matchedTemplate`` : `lsst.afw.image.ExposureF`
+                Warped and PSF-matched template exposure.
+            ``backgroundModel`` : `lsst.afw.math.Function2D`
+                Background model that was fit while solving for the PSF-matching kernel
+            ``psfMatchingKernel`` : `lsst.afw.math.Kernel`
+                Kernel used to PSF-match the convolved image.
+        """
+        return Struct(difference=afwImage.ExposureF(),
+                      matchedTemplate=afwImage.ExposureF(),
+                      backgroundModel=afwMath.NullFunction2D(),
+                      psfMatchingKernel=afwMath.FixedKernel(),
+                      )
 
 
 class MockTransformDiaSourceCatalogTask(PipelineTask):

--- a/tests/MockApPipe.yaml
+++ b/tests/MockApPipe.yaml
@@ -24,14 +24,20 @@ tasks:
       # ap_verify_testdata has bad refcats
       doAstrometry: False
       doPhotoCal: False
-  imageDifference:
-    class: lsst.ap.verify.testPipeline.MockImageDifferenceTask
+  retrieveTemplate:
+    class: lsst.ap.verify.testPipeline.MockGetTemplateTask
     config:
-      doWriteWarpedExp: True             # Required for packaging alerts in diaPipe
-      doSkySources: True
-      coaddName: parameters.coaddName              # Can be removed once ImageDifference no longer supports Gen 2
       connections.coaddName: parameters.coaddName
-      connections.warpedExposure: goodSeeingDiff_templateExp
+  subtractImages:
+    class: lsst.ap.verify.testPipeline.MockAlardLuptonSubtractTask
+    config:
+      connections.coaddName: parameters.coaddName
+      doApplyFinalizedPsf: False
+  detectAndMeasure:
+    class: lsst.ap.verify.testPipeline.MockDetectAndMeasureTask
+    config:
+      connections.coaddName: parameters.coaddName
+      doSkySources: True
   transformDiaSrcCat:
     class: lsst.ap.verify.testPipeline.MockTransformDiaSourceCatalogTask
     config:
@@ -43,23 +49,23 @@ tasks:
       doWriteAssociatedSources: True
       connections.coaddName: parameters.coaddName
 contracts:
-  # DiaPipelineTask needs diaSource fluxes, catalogs, warped exposures, and difference exposures
-  - imageDifference.doMeasurement is True
-  - imageDifference.doWriteSources is True
-  - imageDifference.doWriteWarpedExp is True
-  - imageDifference.doWriteSubtractedExp is True
-  - imageDifference.doSkySources == transformDiaSrcCat.doRemoveSkySources
   # Inputs and outputs must match
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
-  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
-      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
-  - imageDifference.connections.ConnectionsClass(config=imageDifference).diaSources.name ==
-      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
-  - imageDifference.connections.ConnectionsClass(config=imageDifference).subtractedExposure.name ==
-        diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
-  - imageDifference.connections.ConnectionsClass(config=imageDifference).warpedExposure.name ==
-        diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
-  - imageDifference.connections.ConnectionsClass(config=imageDifference).exposure.name ==
+  - retrieveTemplate.connections.ConnectionsClass(config=retrieveTemplate).template.name ==
+      subtractImages.connections.ConnectionsClass(config=subtractImages).template.name
+  - subtractImages.connections.ConnectionsClass(config=subtractImages).difference.name ==
+      detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).difference.name
+  - subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
+      detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).science.name
+  - subtractImages.connections.ConnectionsClass(config=subtractImages).template.name ==
+      diaPipe.connections.ConnectionsClass(config=diaPipe).template.name
+  - subtractImages.connections.ConnectionsClass(config=subtractImages).science.name ==
       diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
+  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
+      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
+  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
+      transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
+  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
+        diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name
   - transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceTable.name ==
         diaPipe.connections.ConnectionsClass(config=diaPipe).diaSourceTable.name

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -36,7 +36,8 @@ import lsst.skymap
 import lsst.daf.butler.tests as butlerTests
 import lsst.pipe.base.testUtils as pipelineTests
 from lsst.ap.verify.testPipeline import MockIsrTask, MockCharacterizeImageTask, \
-    MockCalibrateTask, MockGetTemplateTask, MockImageDifferenceTask, MockTransformDiaSourceCatalogTask, \
+    MockCalibrateTask, MockGetTemplateTask, MockImageDifferenceTask, \
+    MockAlardLuptonSubtractTask, MockTransformDiaSourceCatalogTask, \
     MockDiaPipelineTask
 
 
@@ -111,6 +112,7 @@ class MockTaskTestSuite(unittest.TestCase):
         butlerTests.addDatasetType(cls.repo, "goodSeeingCoadd", cls.patchId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "dcrCoadd", cls.subfilterId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_differenceExp", cls.visitId.keys(), "ExposureF")
+        butlerTests.addDatasetType(cls.repo, "deepDiff_differenceTempExp", cls.visitId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_scoreExp", cls.visitId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_templateExp", cls.visitId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "goodSeeingDiff_templateExp", cls.visitId.keys(), "ExposureF")
@@ -225,6 +227,25 @@ class MockTaskTestSuite(unittest.TestCase):
              "template": self.visitId,
              "matchedExposure": self.visitId,
              "diaSources": self.visitId,
+             })
+        pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
+
+    def testMockAlardLuptonSubtractTask(self):
+        task = MockAlardLuptonSubtractTask()
+        pipelineTests.assertValidInitOutput(task)
+        result = task.run(afwImage.ExposureF(), afwImage.ExposureF(), afwTable.SourceCatalog())
+        pipelineTests.assertValidOutput(task, result)
+
+        self.butler.put(afwImage.ExposureF(), "deepDiff_templateExp", self.visitId)
+        self.butler.put(afwImage.ExposureF(), "calexp", self.visitId)
+        self.butler.put(afwTable.SourceCatalog(), "src", self.visitId)
+        quantum = pipelineTests.makeQuantum(
+            task, self.butler, self.visitId,
+            {"template": self.visitId,
+             "science": self.visitId,
+             "sources": self.visitId,
+             "difference": self.visitId,
+             "matchedTemplate": self.visitId,
              })
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -36,7 +36,7 @@ import lsst.skymap
 import lsst.daf.butler.tests as butlerTests
 import lsst.pipe.base.testUtils as pipelineTests
 from lsst.ap.verify.testPipeline import MockIsrTask, MockCharacterizeImageTask, \
-    MockCalibrateTask, MockGetTemplateTask, MockImageDifferenceTask, \
+    MockCalibrateTask, MockGetTemplateTask, \
     MockAlardLuptonSubtractTask, MockDetectAndMeasureTask, MockTransformDiaSourceCatalogTask, \
     MockDiaPipelineTask
 
@@ -108,12 +108,9 @@ class MockTaskTestSuite(unittest.TestCase):
         butlerTests.addDatasetType(cls.repo, "srcMatchFull", cls.visitId.keys(), "Catalog")
         butlerTests.addDatasetType(cls.repo, lsst.skymap.BaseSkyMap.SKYMAP_DATASET_TYPE_NAME,
                                    cls.skymapId.keys(), "SkyMap")
-        butlerTests.addDatasetType(cls.repo, "deepCoadd", cls.patchId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "goodSeeingCoadd", cls.patchId.keys(), "ExposureF")
-        butlerTests.addDatasetType(cls.repo, "dcrCoadd", cls.subfilterId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_differenceExp", cls.visitId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_differenceTempExp", cls.visitId.keys(), "ExposureF")
-        butlerTests.addDatasetType(cls.repo, "deepDiff_scoreExp", cls.visitId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_templateExp", cls.visitId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "goodSeeingDiff_templateExp", cls.visitId.keys(), "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_matchedExp", cls.visitId.keys(), "ExposureF")
@@ -202,31 +199,6 @@ class MockTaskTestSuite(unittest.TestCase):
              "skyMap": self.skymapId,
              "coaddExposures": [self.patchId],
              "template": self.visitId,
-             })
-        pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
-
-    def testMockImageDifferenceTask(self):
-        task = MockImageDifferenceTask()
-        pipelineTests.assertValidInitOutput(task)
-        result = task.run(afwImage.ExposureF(), templateExposure=afwImage.ExposureF())
-        pipelineTests.assertValidOutput(task, result)
-
-        self.butler.put(afwImage.ExposureF(), "calexp", self.visitId)
-        skymap = lsst.skymap.DiscreteSkyMap(lsst.skymap.DiscreteSkyMapConfig())
-        self.butler.put(skymap, lsst.skymap.BaseSkyMap.SKYMAP_DATASET_TYPE_NAME, self.skymapId)
-        self.butler.put(afwImage.ExposureF(), "deepCoadd", self.patchId)
-        self.butler.put(afwImage.ExposureF(), "dcrCoadd", self.subfilterId)
-        quantum = pipelineTests.makeQuantum(
-            task, self.butler, self.skymapVisitId,
-            {"exposure": self.visitId,
-             "skyMap": self.skymapId,
-             "coaddExposures": [self.patchId],
-             "dcrCoadds": [self.subfilterId],
-             "subtractedExposure": self.visitId,
-             "scoreExposure": self.visitId,
-             "template": self.visitId,
-             "matchedExposure": self.visitId,
-             "diaSources": self.visitId,
              })
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -37,7 +37,7 @@ import lsst.daf.butler.tests as butlerTests
 import lsst.pipe.base.testUtils as pipelineTests
 from lsst.ap.verify.testPipeline import MockIsrTask, MockCharacterizeImageTask, \
     MockCalibrateTask, MockGetTemplateTask, MockImageDifferenceTask, \
-    MockAlardLuptonSubtractTask, MockTransformDiaSourceCatalogTask, \
+    MockAlardLuptonSubtractTask, MockDetectAndMeasureTask, MockTransformDiaSourceCatalogTask, \
     MockDiaPipelineTask
 
 
@@ -246,6 +246,31 @@ class MockTaskTestSuite(unittest.TestCase):
              "sources": self.visitId,
              "difference": self.visitId,
              "matchedTemplate": self.visitId,
+             })
+        pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
+
+    def testMockDetectAndMeasureTask(self):
+        task = MockDetectAndMeasureTask()
+        pipelineTests.assertValidInitOutput(task)
+        result = task.run(science=afwImage.ExposureF(),
+                          matchedTemplate=afwImage.ExposureF(),
+                          difference=afwImage.ExposureF(),
+                          selectSources=afwTable.SourceCatalog(),
+                          )
+        pipelineTests.assertValidOutput(task, result)
+
+        self.butler.put(afwImage.ExposureF(), "calexp", self.visitId)
+        self.butler.put(afwImage.ExposureF(), "deepDiff_matchedExp", self.visitId)
+        self.butler.put(afwImage.ExposureF(), "deepDiff_differenceTempExp", self.visitId)
+        self.butler.put(afwTable.SourceCatalog(), "src", self.visitId)
+        quantum = pipelineTests.makeQuantum(
+            task, self.butler, self.visitId,
+            {"science": self.visitId,
+             "matchedTemplate": self.visitId,
+             "difference": self.visitId,
+             "selectSources": self.visitId,
+             "diaSources": self.visitId,
+             "subtractedMeasuredExposure": self.visitId,
              })
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 


### PR DESCRIPTION
This PR updates `tests/MockApPipe.yaml` and the tasks within it to mirror the current state of the AP pipeline, particularly the new image differencing system. None of these changes directly affect `ap_verify`, which currently only depends on the config for `DiaPipelineTask`, but they will prevent the tests from breaking when `ImageDifferenceTask` is removed.