### PR TITLE
DM-36198: Add parquet transform tasks to ap_verify

### DIFF
--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -6,6 +6,7 @@ imports:
   - location: $AP_PIPE_DIR/pipelines/ApPipe.yaml
   - location: $AP_VERIFY_DIR/pipelines/MetricsRuntime.yaml
   - location: $AP_VERIFY_DIR/pipelines/MetricsMisc.yaml
+  - location: $AP_VERIFY_DIR/pipelines/Conversions.yaml
 tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -7,6 +7,10 @@ imports:
   - location: $AP_VERIFY_DIR/pipelines/MetricsRuntime.yaml
   - location: $AP_VERIFY_DIR/pipelines/MetricsMisc.yaml
   - location: $AP_VERIFY_DIR/pipelines/MetricsForFakes.yaml
+  - location: $AP_VERIFY_DIR/pipelines/Conversions.yaml
+    exclude:
+      # This pipeline doesn't produce non-fakes DiaSourceTable.
+      - consolidateDiaSourceTable
 tasks:
   # Parallel to ApPipe's retrieveTemplateWithFakes, allows non-fakes image differencing.
   retrieveTemplate:

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -7,10 +7,7 @@ imports:
   - location: $AP_VERIFY_DIR/pipelines/MetricsRuntime.yaml
   - location: $AP_VERIFY_DIR/pipelines/MetricsMisc.yaml
   - location: $AP_VERIFY_DIR/pipelines/MetricsForFakes.yaml
-  - location: $AP_VERIFY_DIR/pipelines/Conversions.yaml
-    exclude:
-      # This pipeline doesn't produce non-fakes DiaSourceTable.
-      - consolidateDiaSourceTable
+  - location: $AP_VERIFY_DIR/pipelines/ConversionsForFakes.yaml
 tasks:
   # Parallel to ApPipe's retrieveTemplateWithFakes, allows non-fakes image differencing.
   retrieveTemplate:

--- a/pipelines/Conversions.yaml
+++ b/pipelines/Conversions.yaml
@@ -1,0 +1,37 @@
+# Add-on pipeline designed to be added to ApVerify or ApPipe for QA purposes.
+#
+# This pipeline depends on an external pipeline for the coaddName and fakesType
+# pipeline parameters.
+
+description: Type conversion tasks customized for AP pipeline
+tasks:
+  # Conversion of src [afw.table] to source [Parquet]
+  writeSourceTable:
+    class: lsst.pipe.tasks.postprocess.WriteSourceTableTask
+  # TODO: TransformSourceTableTask can't be run until we create a functor
+  # config that doesn't depend on shapeHSM.
+  # Merging of source [detector-level] to sourceTable_visit [visit-level]
+  consolidateSourceTable:
+    class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
+    config:
+      # Skip DPDD-ified sourceTable and just use source directly
+      connections.inputCatalogs: "{catalogType}source"
+
+  # Merging of *Diff_diaSrcTable [detector-level Parquet] to diaSourceTable [visit-level]
+  consolidateDiaSourceTable:
+    class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
+    config:
+      # Task doesn't support coaddName, so coopt catalogType instead.
+      connections.catalogType: parameters.coaddName
+      connections.inputCatalogs: "{catalogType}Diff_diaSrcTable"
+      connections.outputCatalog: diaSourceTable
+
+  # Creation of visitSummary
+  consolidateVisitSummary:
+    class: lsst.pipe.tasks.postprocess.ConsolidateVisitSummaryTask
+  # Conversion of visitSummary [visit-level afw.table] to visitTable [instrument-level Parquet]
+  makeVisitTable:
+    class: lsst.pipe.tasks.postprocess.MakeVisitTableTask
+  # Conversion of visitSummary [visit-level afw.table] to ccdVisitTable [instrument-level Parquet]
+  makeCcdVisitTable:
+    class: lsst.pipe.tasks.postprocess.MakeCcdVisitTableTask

--- a/pipelines/ConversionsForFakes.yaml
+++ b/pipelines/ConversionsForFakes.yaml
@@ -1,0 +1,54 @@
+# Add-on pipeline designed to be added to ApVerifyWithFakes or ApPipeWithFakes
+# for QA purposes.
+#
+# This pipeline depends on an external pipeline for the coaddName and fakesType
+# pipeline parameters.
+
+description: Type conversion tasks customized for AP pipeline
+imports:
+  - location: $AP_VERIFY_DIR/pipelines/Conversions.yaml
+    exclude:
+      # Fakes pipeline doesn't produce non-fakes DiaSourceTable.
+      - consolidateDiaSourceTable
+tasks:
+  # Conversion of fakes_src [afw.table] to fakes_source [Parquet]
+  writeSourceTableWithFakes:
+    class: lsst.pipe.tasks.postprocess.WriteSourceTableTask
+    config:
+      connections.catalogType: parameters.fakesType
+  # TODO: TransformSourceTableTask can't be run until we create a functor
+  # config that doesn't depend on shapeHSM.
+  # Merging of fakes_source [detector-level] to fakes_sourceTable_visit [visit-level]
+  consolidateSourceTableWithFakes:
+    class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
+    config:
+      connections.catalogType: parameters.fakesType
+      # Skip DPDD-ified sourceTable and just use source directly
+      connections.inputCatalogs: "{catalogType}source"
+
+  # Merging of fakes_*Diff_diaSrcTable [detector-level Parquet] to fakes_diaSourceTable [visit-level]
+  consolidateDiaSourceTableWithFakes:
+    class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
+    config:
+      # Task doesn't support coaddName, so coopt catalogType instead.
+      connections.catalogType: parameters.coaddName
+      # TODO: hard-code the "fakes_" label because I can't insert two templates,
+      # and fakesType is more stable than coaddName.
+      connections.inputCatalogs: "fakes_{catalogType}Diff_diaSrcTable"
+      connections.outputCatalog: fakes_diaSourceTable
+
+  # Creation of fakes_visitSummary
+  consolidateVisitSummaryWithFakes:
+    class: lsst.pipe.tasks.postprocess.ConsolidateVisitSummaryTask
+    config:
+      connections.calexpType: parameters.fakesType
+  # Conversion of fakes_visitSummary [visit-level afw.table] to fakes_visitTable [instrument-level Parquet]
+  makeVisitTable:
+    class: lsst.pipe.tasks.postprocess.MakeVisitTableTask
+    config:
+      connections.calexpType: parameters.fakesType
+  # Conversion of fakes_visitSummary [visit-level afw.table] to fakes_ccdVisitTable [instrument-level Parquet]
+  makeCcdVisitTable:
+    class: lsst.pipe.tasks.postprocess.MakeCcdVisitTableTask
+    config:
+      connections.calexpType: parameters.fakesType


### PR DESCRIPTION
This PR adds extra Parquet transformation tasks to both `ap_verify` pipelines. These tasks are not needed (or used) in CI, but make it easier to make plots of `ap_verify` datasets in `analysis_tools`.