### PR TITLE
DM-33039: Update dataset specification

### DIFF
--- a/doc/lsst.ap.verify/datasets-creation.rst
+++ b/doc/lsst.ap.verify/datasets-creation.rst
@@ -32,6 +32,7 @@ Organizing the data
 * The :file:`raw` directory contains uningested science data.
   The directory may have any internal structure.
 * The :file:`preloaded` directory contains a :ref:`Gen 3 LSST Butler repository<lsst.daf.butler-using>` with calibration data, coadded difference imaging templates, refcats, and any other files needed for processing science data.
+  The repository must have an ``<instrument>/defaults`` collection containing all of the above.
   It must not contain science data, which belongs only in :file:`raw`.
 * The :file:`config/export.yaml` file is a `relative-path export <lsst.daf.butler.Butler.export>` of the repository at :file:`preloaded`, used to set up a separate repository for running ``ap_verify``.
 * The :file:`config` and :file:`pipelines` directories contain :ref:`configuration overrides needed to run the AP pipeline on the data<ap-verify-datasets-creation-config>`.


### PR DESCRIPTION
The `ap_verify` code assumes that the dataset's preloaded repository puts everything except raws in a `defaults/` collection, but this requirement was not documented. This PR fixes that.