### PR TITLE
DM-37807: fix broken ApVerifyWithFakes pipeline

### DIFF
--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -33,6 +33,11 @@ tasks:
     config:
       connections.labelName: transformDiaSrcCatWithFakes  # Default is transformDiaSrcCat
       target: transformDiaSrcCatWithFakes.run
+  cputiming_transformDiaSrcCat:
+    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
+    config:
+      connections.labelName: transformDiaSrcCatWithFakes  # Default is transformDiaSrcCat
+      target: transformDiaSrcCatWithFakes.run
 subsets:
   apPipe:
     # Extend the subset through imageDifference.

--- a/pipelines/MetricsRuntime.yaml
+++ b/pipelines/MetricsRuntime.yaml
@@ -1,5 +1,8 @@
 # Timing and system resource metrics for Alert Production
 
+# Note that some of these configs must be overridden in ApVerifyWithFakes.yaml,
+# because some task names differ from ApVerify.yaml.
+
 description: Runtime metrics (customized for AP pipeline)
 tasks:
   timing_isr:


### PR DESCRIPTION
`ApVerifyWithFakes` has a `transformDiaSrcCatWithFakes` task, but not a `transformDiaSrcCat`. This caused quantum graph errors when `cputiming_transformDiaSrcCat` was added in #180 and configured only for `ApVerify`.