### PR TITLE
DM-36477: Remove ap_verify_hits2015 dataset

### DIFF
--- a/doc/lsst.ap.verify/datasets-install.rst
+++ b/doc/lsst.ap.verify/datasets-install.rst
@@ -28,7 +28,7 @@ Installation procedure
 
 Use the `LSST Software Build Tool <https://developer.lsst.io/stack/lsstsw.html>`_ to request the dataset by its package name.
 A :ref:`list of supported datasets <ap-verify-datasets-index>` is maintained as part of this documentation.
-Because of their large size (typically hundreds of GB), datasets are *never* installed as a dependency of another package; they must be requested explicitly.
+Because of their large size (typically several GB), datasets are *never* installed as a dependency of another package; they must be requested explicitly.
 
 For example, to install the `Cosmos PDR2 <https://github.com/lsst/ap_verify_ci_cosmos_pdr2/>`_ CI dataset,
 

--- a/doc/lsst.ap.verify/running.rst
+++ b/doc/lsst.ap.verify/running.rst
@@ -57,11 +57,6 @@ while the output is:
 
 This call will create a new directory at :file:`workspaces/cosmos`, ingest the Cosmos data into a new repository, then run visits 59150 and 59160 through the entire AP pipeline.
 
-.. warning::
-
-    Some datasets require particular :ref:`data ID queries <daf_butler_dimension_expressions>` (e.g. ``--data-query "visit in ..."``) in order to successfully run through the pipeline, due to missing data or other limitations.
-    Check the ``README.md`` in each dataset's main directory for what additional arguments might be necessary.
-
 
 .. _ap-verify-run-ingest:
 

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -215,9 +215,6 @@ def _getApdbArguments(workspace, parsed):
         parsed.db = "sqlite:///" + workspace.dbLocation
 
     args = ["--config", "db_url=" + parsed.db]
-    # Same special-case check as ApdbConfig.validate()
-    if parsed.db.startswith("sqlite"):
-        args.extend(["--config", "isolation_level=READ_UNCOMMITTED"])
 
     return args
 


### PR DESCRIPTION
This PR updates our documentation to reflect the fact that now all `ap_verify` datasets are "CI-sized", and patches up some long-standing technical debt in `pipeline_driver`.