### PR TITLE
DM-40210: Clean up ap_pipe and ap_verify pipelines

### DIFF
--- a/pipelines/DarkEnergyCamera/ApVerify.yaml
+++ b/pipelines/DarkEnergyCamera/ApVerify.yaml
@@ -15,15 +15,6 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True
-  transformDiaSrcCat:
-    class: lsst.ap.association.TransformDiaSourceCatalogTask
-    config:
-      doIncludeReliability: True
-  rbClassify:
-    class: lsst.meas.transiNet.RBTransiNetTask
-    config:
-      modelPackageName: 'rbResnet50-DC2'
-      connections.coaddName: parameters.coaddName
 contracts:
   # Must re-declare contracts that cross apPipe and metrics boundary, as
   # these were removed on import.

--- a/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
+++ b/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
@@ -15,12 +15,6 @@ imports:
   # because the changes made by that file and _ingredients/ApVerifyWithFakes.yaml
   # are hard to separate.
 tasks:
-  processVisitFakes:
-    class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
-    config:
-      # Mirror calibrate config from DarkEnergyCamera/ProcessCcd.yaml
-      calibrate.photoCal.match.referenceSelection.magLimit.fluxField: i_flux
-      calibrate.photoCal.match.referenceSelection.magLimit.maximum: 22.0
   transformDiaSrcCatWithFakes:
     class: lsst.ap.association.TransformDiaSourceCatalogTask
     config:

--- a/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
+++ b/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
@@ -12,8 +12,8 @@ imports:
       - processCcd
   - location: $AP_PIPE_DIR/pipelines/DarkEnergyCamera/ProcessCcd.yaml
   # Can't use $AP_PIPE_DIR/pipelines/DarkEnergyCamera/ApPipeWithFakes.yaml here
-  # because the changes made by that file and ../ApVerifyWithFakes.yaml are
-  # hard to separate.
+  # because the changes made by that file and _ingredients/ApVerifyWithFakes.yaml
+  # are hard to separate.
 tasks:
   processVisitFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask

--- a/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
+++ b/pipelines/DarkEnergyCamera/ApVerifyWithFakes.yaml
@@ -14,14 +14,3 @@ imports:
   # Can't use $AP_PIPE_DIR/pipelines/DarkEnergyCamera/ApPipeWithFakes.yaml here
   # because the changes made by that file and _ingredients/ApVerifyWithFakes.yaml
   # are hard to separate.
-tasks:
-  transformDiaSrcCatWithFakes:
-    class: lsst.ap.association.TransformDiaSourceCatalogTask
-    config:
-      doIncludeReliability: True
-  rbClassify:
-    class: lsst.meas.transiNet.RBTransiNetTask
-    config:
-      modelPackageName: 'rbResnet50-DC2'
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType

--- a/pipelines/HyperSuprimeCam/ApVerify.yaml
+++ b/pipelines/HyperSuprimeCam/ApVerify.yaml
@@ -15,15 +15,6 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True
-  transformDiaSrcCat:
-    class: lsst.ap.association.TransformDiaSourceCatalogTask
-    config:
-      doIncludeReliability: True
-  rbClassify:
-    class: lsst.meas.transiNet.RBTransiNetTask
-    config:
-      modelPackageName: 'rbResnet50-DC2'
-      connections.coaddName: parameters.coaddName
 contracts:
   # Must re-declare contracts that cross apPipe and metrics boundary, as
   # these were removed on import.

--- a/pipelines/HyperSuprimeCam/ApVerifyWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApVerifyWithFakes.yaml
@@ -9,8 +9,8 @@ imports:
       - processCcd
   - location: $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ProcessCcd.yaml
   # Can't use $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml here
-  # because the changes made by that file and ../ApVerifyWithFakes.yaml are
-  # hard to separate.
+  # because the changes made by that file and _ingredients/ApVerifyWithFakes.yaml
+  # are hard to separate.
 
 tasks:
   transformDiaSrcCatWithFakes:

--- a/pipelines/HyperSuprimeCam/ApVerifyWithFakes.yaml
+++ b/pipelines/HyperSuprimeCam/ApVerifyWithFakes.yaml
@@ -11,15 +11,3 @@ imports:
   # Can't use $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ApPipeWithFakes.yaml here
   # because the changes made by that file and _ingredients/ApVerifyWithFakes.yaml
   # are hard to separate.
-
-tasks:
-  transformDiaSrcCatWithFakes:
-    class: lsst.ap.association.TransformDiaSourceCatalogTask
-    config:
-      doIncludeReliability: True
-  rbClassify:
-    class: lsst.meas.transiNet.RBTransiNetTask
-    config:
-      modelPackageName: 'rbResnet50-DC2'
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType

--- a/pipelines/LSSTCam-imSim/ApVerify.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerify.yaml
@@ -15,15 +15,6 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True
-  transformDiaSrcCat:
-    class: lsst.ap.association.TransformDiaSourceCatalogTask
-    config:
-      doIncludeReliability: True
-  rbClassify:
-    class: lsst.meas.transiNet.RBTransiNetTask
-    config:
-      modelPackageName: 'rbResnet50-DC2'
-      connections.coaddName: parameters.coaddName
 contracts:
   # Must re-declare contracts that cross apPipe and metrics boundary, as
   # these were removed on import.

--- a/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
@@ -9,8 +9,8 @@ imports:
       - processCcd
   - location: $AP_PIPE_DIR/pipelines/LsstCamImSim/ProcessCcd.yaml
   # Can't use $AP_PIPE_DIR/pipelines/LsstCamImSim/ApPipeWithFakes.yaml here
-  # because the changes made by that file and ../ApVerifyWithFakes.yaml are
-  # hard to separate.
+  # because the changes made by that file and _ingredients/ApVerifyWithFakes.yaml
+  # are hard to separate.
 
 tasks:
   transformDiaSrcCatWithFakes:

--- a/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
@@ -11,15 +11,3 @@ imports:
   # Can't use $AP_PIPE_DIR/pipelines/LsstCamImSim/ApPipeWithFakes.yaml here
   # because the changes made by that file and _ingredients/ApVerifyWithFakes.yaml
   # are hard to separate.
-
-tasks:
-  transformDiaSrcCatWithFakes:
-    class: lsst.ap.association.TransformDiaSourceCatalogTask
-    config:
-      doIncludeReliability: True
-  rbClassify:
-    class: lsst.meas.transiNet.RBTransiNetTask
-    config:
-      modelPackageName: 'rbResnet50-DC2'
-      connections.coaddName: parameters.coaddName
-      connections.fakesType: parameters.fakesType

--- a/pipelines/_ingredients/ApVerify.yaml
+++ b/pipelines/_ingredients/ApVerify.yaml
@@ -14,6 +14,20 @@ tasks:
       # TODO: needed for "providing bulk sample alerts to brokers"; remove once
       # we have an alternative.
       doPackageAlerts: True
+  # TODO: rbClassify and doIncludeReliability logically belong in ap_pipe, but
+  # having ap_pipe require manual setup of rbClassifier_data would cause too
+  # many problems. Move to ApPipe.yaml once either DM-38454 is implemented (and
+  # weights added to standard repos) or rbClassifier_data is fully integrated
+  # with the stack.
+  rbClassify:
+    class: lsst.meas.transiNet.RBTransiNetTask
+    config:
+      modelPackageName: rbResnet50-DC2   # Useful for non-DC2 data as well
+      connections.coaddName: parameters.coaddName
+  transformDiaSrcCat:
+    class: lsst.ap.association.TransformDiaSourceCatalogTask
+    config:
+      doIncludeReliability: True  # Output from rbClassify
 contracts:
   # Metric inputs must match pipeline outputs
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210

--- a/pipelines/_ingredients/ApVerify.yaml
+++ b/pipelines/_ingredients/ApVerify.yaml
@@ -22,6 +22,7 @@ tasks:
   rbClassify:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
+      modelPackageStorageMode: neighbor  # Mode of rbResnet50-DC2
       modelPackageName: rbResnet50-DC2   # Useful for non-DC2 data as well
       connections.coaddName: parameters.coaddName
   transformDiaSrcCat:

--- a/pipelines/_ingredients/ApVerify.yaml
+++ b/pipelines/_ingredients/ApVerify.yaml
@@ -11,6 +11,8 @@ tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
+      # TODO: needed for "providing bulk sample alerts to brokers"; remove once
+      # we have an alternative.
       doPackageAlerts: True
 contracts:
   # Metric inputs must match pipeline outputs

--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -27,6 +27,8 @@ tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
+      # TODO: needed for "providing bulk sample alerts to brokers"; remove once
+      # we have an alternative.
       doPackageAlerts: True
   timing_transformDiaSrcCat:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask

--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -30,6 +30,21 @@ tasks:
       # TODO: needed for "providing bulk sample alerts to brokers"; remove once
       # we have an alternative.
       doPackageAlerts: True
+  # TODO: rbClassify and doIncludeReliability logically belong in ap_pipe, but
+  # having ap_pipe require manual setup of rbClassifier_data would cause too
+  # many problems. Move to ApPipeWithFakes.yaml once either DM-38454 is
+  # implemented (and weights added to standard repos) or rbClassifier_data is
+  # fully integrated with the stack.
+  rbClassifyWithFakes:
+    class: lsst.meas.transiNet.RBTransiNetTask
+    config:
+      modelPackageName: rbResnet50-DC2   # Useful for non-DC2 data as well
+      connections.coaddName: parameters.coaddName
+      connections.fakesType: parameters.fakesType
+  transformDiaSrcCatWithFakes:
+    class: lsst.ap.association.TransformDiaSourceCatalogTask
+    config:
+      doIncludeReliability: True  # Output from rbClassify
   timing_transformDiaSrcCat:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:

--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -38,6 +38,7 @@ tasks:
   rbClassifyWithFakes:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
+      modelPackageStorageMode: neighbor  # Mode of rbResnet50-DC2
       modelPackageName: rbResnet50-DC2   # Useful for non-DC2 data as well
       connections.coaddName: parameters.coaddName
       connections.fakesType: parameters.fakesType


### PR DESCRIPTION
This PR merges the `rbClassify` task from instrument-specific pipelines to the base (`_ingredients`) pipeline and removes some configs that are redundant at the instrument level. This leaves the pipelines cleaner and with clearer responsibilities, and will prevent changes to the base pipeline from unexpectedly not working.

Unfortunately, the `ApVerify` pipeline still contains a few elements that should be in `ApPipe` but that shouldn't be moved at this time. These have been marked with TODO comments.