### PR TITLE
DM-40629: Add GitHub PR template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+{Summary of changes. Prefix PR title with JIRA issue.}
+
+****
+
+- [ ] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
+- [ ] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
+- [ ] Is the Sphinx documentation up-to-date?


### PR DESCRIPTION
This PR adds a PR template reminding developers to run `ap_verify.py` for testing. Unfortunately, this PR is not a self-demonstrating example.