### PR TITLE
DM-40650: RBTransiNet runtime not being measured

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,5 @@
 
 - [ ] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
 - [ ] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
+      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
 - [ ] Is the Sphinx documentation up-to-date?

--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -59,6 +59,16 @@ tasks:
     config:
       connections.labelName: transformDiaSrcCatWithFakes  # Default is transformDiaSrcCat
       target: transformDiaSrcCatWithFakes.run
+  timing_rbClassify:
+    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+    config:
+      connections.labelName: rbClassifyWithFakes  # Default is rbClassify
+      target: rbClassifyWithFakes.run
+  cputiming_rbClassify:
+    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
+    config:
+      connections.labelName: rbClassifyWithFakes  # Default is rbClassify
+      target: rbClassifyWithFakes.run
 subsets:
   apPipe:
     # Extend the subset through imageDifference.


### PR DESCRIPTION
This PR adds a config fix to let `*timing_rbClassify` run in the Fakes pipeline.

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
- [ ] Is the Sphinx documentation up-to-date?
