### PR TITLE
DM-41024: Add longTrailedSources to testPipeline unit tests

### DIFF
--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -568,4 +568,5 @@ class MockDiaPipelineTask(PipelineTask):
                       associatedDiaSources=pandas.DataFrame(),
                       diaForcedSources=pandas.DataFrame(),
                       diaObjects=pandas.DataFrame(),
+                      longTrailedSources=pandas.DataFrame(),
                       )

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -120,7 +120,8 @@ class MockTaskTestSuite(unittest.TestCase):
         butlerTests.addDatasetType(cls.repo, "deepDiff_diaSrcTable", cls.visitId.keys(), "DataFrame")
         butlerTests.addDatasetType(cls.repo, "visitSsObjects", cls.visitOnlyId.keys(), "DataFrame")
         butlerTests.addDatasetType(cls.repo, "apdb_marker", cls.visitId.keys(), "Config")
-        butlerTests.addDatasetType(cls.repo, "deepDiff_associDiaSrc", cls.visitId.keys(), "DataFrame")
+        butlerTests.addDatasetType(cls.repo, "deepDiff_assocDiaSrc", cls.visitId.keys(), "DataFrame")
+        butlerTests.addDatasetType(cls.repo, "deepDiff_longTrailedSrc", cls.visitId.keys(), "DataFrame")
 
     def setUp(self):
         super().setUp()
@@ -285,6 +286,7 @@ class MockTaskTestSuite(unittest.TestCase):
              "template": self.visitId,
              "apdbMarker": self.visitId,
              "associatedDiaSources": self.visitId,
+             "longTrailedSources": self.visitId,
              })
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 


### PR DESCRIPTION
longTrailedSources needs to be added to the unit test output otherwise ap_verify fails to scons.