### PR TITLE
DM-38247: Use long-log for ap_verify runs

### DIFF
--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -95,6 +95,9 @@ def runApPipeGen3(workspace, parsedCmdLine, processes=1):
 
     pipelineFile = _getPipelineFile(workspace, parsedCmdLine)
     pipelineArgs = ["pipetask", "--long-log", "run",
+                    # fail-fast to ensure processing errors are obvious, and
+                    # to compensate for the extra interconnections added by
+                    # --graph-fixup (further down).
                     "--fail-fast",
                     "--butler-config", workspace.repo,
                     "--pipeline", pipelineFile,

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -94,7 +94,7 @@ def runApPipeGen3(workspace, parsedCmdLine, processes=1):
     makeApdb(_getApdbArguments(workspace, parsedCmdLine))
 
     pipelineFile = _getPipelineFile(workspace, parsedCmdLine)
-    pipelineArgs = ["pipetask", "run",
+    pipelineArgs = ["pipetask", "--long-log", "run",
                     "--fail-fast",
                     "--butler-config", workspace.repo,
                     "--pipeline", pipelineFile,


### PR DESCRIPTION
{Summary of changes. Prefix PR title with JIRA issue.}

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [X] Is the Sphinx documentation up-to-date?
