### PR TITLE
DM-40798: Exclude sky sources from RB classification

### DIFF
--- a/pipelines/_ingredients/MetricsRuntime.yaml
+++ b/pipelines/_ingredients/MetricsRuntime.yaml
@@ -119,6 +119,13 @@ tasks:
       connections.metric: PackageAlertsTime
       connections.labelName: diaPipe
       target: diaPipe:alertPackager.run
+  timing_filterDiaSrcCat:
+    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+    config:
+      connections.package: ap_association
+      connections.metric: FilterDiaSourceCatalogTime
+      connections.labelName: filterDiaSrcCat
+      target: filterDiaSrcCat.run
   cputiming_isr:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
@@ -233,6 +240,13 @@ tasks:
       connections.metric: PackageAlertsCpuTime
       connections.labelName: diaPipe
       target: diaPipe:alertPackager.run
+  cputiming_filterDiaSrcCat:
+    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+    config:
+      connections.package: ap_association
+      connections.metric: FilterDiaSourceCatalogCpuTime
+      connections.labelName: filterDiaSrcCat
+      target: filterDiaSrcCat.run
   memory_apPipe:
     class: lsst.verify.tasks.commonMetrics.MemoryMetricTask
     config:

--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -34,13 +34,14 @@ import lsst.geom as geom
 import lsst.afw.image as afwImage
 import lsst.afw.math as afwMath
 import lsst.afw.table as afwTable
+from lsst.ap.association import (TransformDiaSourceCatalogConfig,
+                                 DiaPipelineConfig, FilterDiaSourceCatalogConfig)
 from lsst.pipe.base import PipelineTask, Struct
 from lsst.ip.isr import IsrTaskConfig
 from lsst.ip.diffim import GetTemplateConfig, AlardLuptonSubtractConfig, DetectAndMeasureConfig
 from lsst.pipe.tasks.characterizeImage import CharacterizeImageConfig
 from lsst.pipe.tasks.calibrate import CalibrateConfig
 from lsst.meas.transiNet import RBTransiNetConfig
-from lsst.ap.association import TransformDiaSourceCatalogConfig, DiaPipelineConfig
 
 
 class MockIsrTask(PipelineTask):
@@ -431,6 +432,30 @@ class MockDetectAndMeasureTask(PipelineTask):
         """
         return Struct(subtractedMeasuredExposure=difference,
                       diaSources=afwTable.SourceCatalog(),
+                      )
+
+
+class MockFilterDiaSourceCatalogTask(PipelineTask):
+    """A do-nothing substitute for FilterDiaSourceCatalogTask.
+    """
+    ConfigClass = FilterDiaSourceCatalogConfig
+    _DefaultName = "notFilterDiaSourceCatalog"
+
+    def run(self, diaSourceCat):
+        """Produce filtering outputs with no processing.
+
+        Parameters
+        ----------
+        diaSourceCat : `lsst.afw.table.SourceCatalog`
+            Catalog of sources measured on the difference image.
+
+        Returns
+        -------
+        results : `lsst.pipe.base.Struct`
+            Results struct with components.
+        """
+        return Struct(filteredDiaSourceCat=afwTable.SourceCatalog(),
+                      rejectedDiaSources=afwTable.SourceCatalog(),
                       )
 
 

--- a/tests/MockApPipe.yaml
+++ b/tests/MockApPipe.yaml
@@ -35,6 +35,11 @@ tasks:
     config:
       connections.coaddName: parameters.coaddName
       doSkySources: True
+  filterDiaSrcCat:
+    class: lsst.ap.verify.testPipeline.MockFilterDiaSourceCatalogTask
+    config:
+      doRemoveSkySources: True
+      connections.coaddName: parameters.coaddName
   rbClassify:
     class: lsst.ap.verify.testPipeline.MockRBTransiNetTask
     config:
@@ -65,11 +70,13 @@ contracts:
       diaPipe.connections.ConnectionsClass(config=diaPipe).exposure.name
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
       rbClassify.connections.ConnectionsClass(config=rbClassify).difference.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
+  - filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
       rbClassify.connections.ConnectionsClass(config=rbClassify).diaSources.name
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
       transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diffIm.name
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
+      filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).diaSourceCat.name
+  - filterDiaSrcCat.connections.ConnectionsClass(config=filterDiaSrcCat).filteredDiaSourceCat.name ==
       transformDiaSrcCat.connections.ConnectionsClass(config=transformDiaSrcCat).diaSourceCat.name
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).subtractedMeasuredExposure.name ==
         diaPipe.connections.ConnectionsClass(config=diaPipe).diffIm.name

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -38,7 +38,7 @@ import lsst.pipe.base.testUtils as pipelineTests
 from lsst.ap.verify.testPipeline import MockIsrTask, MockCharacterizeImageTask, \
     MockCalibrateTask, MockGetTemplateTask, \
     MockAlardLuptonSubtractTask, MockDetectAndMeasureTask, MockTransformDiaSourceCatalogTask, \
-    MockRBTransiNetTask, MockDiaPipelineTask
+    MockRBTransiNetTask, MockDiaPipelineTask, MockFilterDiaSourceCatalogTask
 
 
 class MockTaskTestSuite(unittest.TestCase):
@@ -121,6 +121,8 @@ class MockTaskTestSuite(unittest.TestCase):
         butlerTests.addDatasetType(cls.repo, "deepDiff_matchedExp", cls.visitId.dimensions, "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_diaSrc", cls.visitId.dimensions, "SourceCatalog")
         butlerTests.addDatasetType(cls.repo, "deepDiff_diaSrcTable", cls.visitId.dimensions, "DataFrame")
+        butlerTests.addDatasetType(cls.repo, "deepDiff_candidateDiaSrc", cls.visitId.dimensions,
+                                   "SourceCatalog")
         butlerTests.addDatasetType(cls.repo, "visitSsObjects", cls.visitOnlyId.dimensions, "DataFrame")
         butlerTests.addDatasetType(cls.repo, "apdb_marker", cls.visitId.dimensions, "Config")
         butlerTests.addDatasetType(cls.repo, "deepDiff_assocDiaSrc", cls.visitId.dimensions, "DataFrame")
@@ -251,6 +253,12 @@ class MockTaskTestSuite(unittest.TestCase):
              })
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 
+    def testMockFilterDiaSourceCatalogTask(self):
+        task = MockFilterDiaSourceCatalogTask()
+        pipelineTests.assertValidInitOutput(task)
+        result = task.run(afwTable.SourceCatalog())
+        pipelineTests.assertValidOutput(task, result)
+
     def testMockRBTransiNetTask(self):
         task = MockRBTransiNetTask()
         pipelineTests.assertValidInitOutput(task)
@@ -264,7 +272,7 @@ class MockTaskTestSuite(unittest.TestCase):
         self.butler.put(afwImage.ExposureF(), "calexp", self.visitId)
         self.butler.put(afwImage.ExposureF(), "deepDiff_differenceExp", self.visitId)
         self.butler.put(afwImage.ExposureF(), "deepDiff_templateExp", self.visitId)
-        self.butler.put(afwTable.SourceCatalog(), "deepDiff_diaSrc", self.visitId)
+        self.butler.put(afwTable.SourceCatalog(), "deepDiff_candidateDiaSrc", self.visitId)
         quantum = pipelineTests.makeQuantum(
             task, self.butler, self.visitId,
             {"template": self.visitId,
@@ -282,7 +290,7 @@ class MockTaskTestSuite(unittest.TestCase):
         result = task.run(afwTable.SourceCatalog(), afwImage.ExposureF(), 'k', 42)
         pipelineTests.assertValidOutput(task, result)
 
-        self.butler.put(afwTable.SourceCatalog(), "deepDiff_diaSrc", self.visitId)
+        self.butler.put(afwTable.SourceCatalog(), "deepDiff_candidateDiaSrc", self.visitId)
         self.butler.put(afwImage.ExposureF(), "deepDiff_differenceExp", self.visitId)
         quantum = pipelineTests.makeQuantum(
             task, self.butler, self.visitId,


### PR DESCRIPTION
{Summary of changes. Prefix PR title with JIRA issue.}

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x] Is the Sphinx documentation up-to-date?
