### PR TITLE
DM-33453: Update pipeline references in response to RFC-775. (Hotfix)

### DIFF
--- a/pipelines/LSSTCam-imSim/ApVerify.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerify.yaml
@@ -8,7 +8,7 @@ imports:
     # a metrics subset because it would require constant micromanagement.
     exclude:
       - apPipe
-  - location: $AP_PIPE_DIR/pipelines/LsstCamImSim/ApPipe.yaml
+  - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApPipe.yaml
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/LSSTCam-imSim/ApVerifyCalibrateImage.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerifyCalibrateImage.yaml
@@ -9,7 +9,7 @@ imports:
     # a metrics subset because it would require constant micromanagement.
     exclude:
       - apPipe
-  - location: $AP_PIPE_DIR/pipelines/LsstCamImSim/ApPipeCalibrateImage.yaml
+  - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApPipeCalibrateImage.yaml
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
@@ -7,7 +7,7 @@ imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ApVerifyWithFakes.yaml
     exclude:
       - processCcd
-  - location: $AP_PIPE_DIR/pipelines/LsstCamImSim/ProcessCcd.yaml
-  # Can't use $AP_PIPE_DIR/pipelines/LsstCamImSim/ApPipeWithFakes.yaml here
+  - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ProcessCcd.yaml
+  # Can't use $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml here
   # because the changes made by that file and _ingredients/ApVerifyWithFakes.yaml
   # are hard to separate.


### PR DESCRIPTION
Corrected missed files in original fix. Changed `LSSTCamImSim` to `LSSTCam-imSim` in response to RFC-775.