### PR TITLE
DM-42818: ApVerifyWithFakes broken in w_2024_06

### DIFF
--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -33,6 +33,16 @@ tasks:
       # TODO: needed for "providing bulk sample alerts to brokers"; remove once
       # we have an alternative.
       doPackageAlerts: True
+  timing_filterDiaSrcCat:
+    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+    config:
+      connections.labelName: filterDiaSrcCatWithFakes  # Default is filterDiaSrcCat
+      target: filterDiaSrcCatWithFakes.run
+  cputiming_filterDiaSrcCat:
+    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
+    config:
+      connections.labelName: filterDiaSrcCatWithFakes  # Default is filterDiaSrcCat
+      target: filterDiaSrcCatWithFakes.run
   timing_rbClassify:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:

--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -33,16 +33,6 @@ tasks:
       # TODO: needed for "providing bulk sample alerts to brokers"; remove once
       # we have an alternative.
       doPackageAlerts: True
-  timing_transformDiaSrcCat:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.labelName: transformDiaSrcCatWithFakes  # Default is transformDiaSrcCat
-      target: transformDiaSrcCatWithFakes.run
-  cputiming_transformDiaSrcCat:
-    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
-    config:
-      connections.labelName: transformDiaSrcCatWithFakes  # Default is transformDiaSrcCat
-      target: transformDiaSrcCatWithFakes.run
   timing_rbClassify:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
@@ -53,6 +43,16 @@ tasks:
     config:
       connections.labelName: rbClassifyWithFakes  # Default is rbClassify
       target: rbClassifyWithFakes.run
+  timing_transformDiaSrcCat:
+    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+    config:
+      connections.labelName: transformDiaSrcCatWithFakes  # Default is transformDiaSrcCat
+      target: transformDiaSrcCatWithFakes.run
+  cputiming_transformDiaSrcCat:
+    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
+    config:
+      connections.labelName: transformDiaSrcCatWithFakes  # Default is transformDiaSrcCat
+      target: transformDiaSrcCatWithFakes.run
 subsets:
   apPipe:
     # Extend the subset through imageDifference.

--- a/pipelines/_ingredients/MetricsRuntime.yaml
+++ b/pipelines/_ingredients/MetricsRuntime.yaml
@@ -241,7 +241,7 @@ tasks:
       connections.labelName: diaPipe
       target: diaPipe:alertPackager.run
   cputiming_filterDiaSrcCat:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
+    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: FilterDiaSourceCatalogCpuTime


### PR DESCRIPTION
This PR fixes a couple of configuration errors in `timing_filterDiaSrcCat` and `cputiming_filterDiaSrcCat`.

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ ] Is the Sphinx documentation up-to-date?
