### PR TITLE
DM-42419: Break up ApVerify into pure with- and without-fakes pipelines

### DIFF
--- a/pipelines/_ingredients/ApVerify.yaml
+++ b/pipelines/_ingredients/ApVerify.yaml
@@ -4,6 +4,7 @@
 description: Fully instrumented AP pipeline
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
+  # Metrics that should be run without fakes
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/MetricsRuntime.yaml
     exclude:
       - timing_calibrateImage

--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -4,11 +4,7 @@
 description: Fully instrumented AP pipeline with fakes
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
-  - location: $AP_VERIFY_DIR/pipelines/_ingredients/MetricsRuntime.yaml
-    exclude:
-      - timing_calibrateImage
-      - cputiming_calibrateImage
-  - location: $AP_VERIFY_DIR/pipelines/_ingredients/MetricsMisc.yaml
+  # Most metrics should not be run with fakes, to avoid bias or contamination.
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/MetricsForFakes.yaml
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ConversionsForFakes.yaml
 tasks:
@@ -33,36 +29,6 @@ tasks:
       # TODO: needed for "providing bulk sample alerts to brokers"; remove once
       # we have an alternative.
       doPackageAlerts: True
-  timing_filterDiaSrcCat:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.labelName: filterDiaSrcCatWithFakes  # Default is filterDiaSrcCat
-      target: filterDiaSrcCatWithFakes.run
-  cputiming_filterDiaSrcCat:
-    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
-    config:
-      connections.labelName: filterDiaSrcCatWithFakes  # Default is filterDiaSrcCat
-      target: filterDiaSrcCatWithFakes.run
-  timing_rbClassify:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.labelName: rbClassifyWithFakes  # Default is rbClassify
-      target: rbClassifyWithFakes.run
-  cputiming_rbClassify:
-    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
-    config:
-      connections.labelName: rbClassifyWithFakes  # Default is rbClassify
-      target: rbClassifyWithFakes.run
-  timing_transformDiaSrcCat:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.labelName: transformDiaSrcCatWithFakes  # Default is transformDiaSrcCat
-      target: transformDiaSrcCatWithFakes.run
-  cputiming_transformDiaSrcCat:
-    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
-    config:
-      connections.labelName: transformDiaSrcCatWithFakes  # Default is transformDiaSrcCat
-      target: transformDiaSrcCatWithFakes.run
 subsets:
   apPipe:
     # Extend the subset through imageDifference.
@@ -82,5 +48,3 @@ contracts:
       apFakesCompletenessMag22t24.connections.ConnectionsClass(config=apFakesCompletenessMag22t24).matchedFakes.name
   - fakesMatch.connections.ConnectionsClass(config=fakesMatch).matchedDiaSources.name ==
       apFakesCompletenessMag24t26.connections.ConnectionsClass(config=apFakesCompletenessMag24t26).matchedFakes.name
-  - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
-      fracDiaSourcesToSciSources.connections.ConnectionsClass(config=fracDiaSourcesToSciSources).diaSources.name

--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -8,37 +8,12 @@ imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/MetricsForFakes.yaml
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ConversionsForFakes.yaml
 tasks:
-  # Parallel to ApPipe's retrieveTemplateWithFakes, allows non-fakes image differencing.
-  retrieveTemplate:
-    class: lsst.ip.diffim.getTemplate.GetTemplateTask
-    config:
-        connections.coaddName: parameters.coaddName
-  # Parallel to ApPipe's imageDifferenceWithFakes, allows clean differencing metrics.
-  subtractImages:
-    class: lsst.ip.diffim.subtractImages.AlardLuptonSubtractTask
-    config:
-      connections.coaddName: parameters.coaddName
-  detectAndMeasure:
-    class: lsst.ip.diffim.detectAndMeasure.DetectAndMeasureTask
-    config:
-      connections.coaddName: parameters.coaddName
-      doSkySources: True
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
       # TODO: needed for "providing bulk sample alerts to brokers"; remove once
       # we have an alternative.
       doPackageAlerts: True
-subsets:
-  apPipe:
-    # Extend the subset through imageDifference.
-    subset:
-      - isr
-      - characterizeImage
-      - calibrate
-      - retrieveTemplate
-      - subtractImages
-      - detectAndMeasure
 contracts:
   # Metric inputs must match pipeline outputs
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210

--- a/pipelines/_ingredients/ConversionsForFakes.yaml
+++ b/pipelines/_ingredients/ConversionsForFakes.yaml
@@ -12,14 +12,14 @@ imports:
       - consolidateDiaSourceTable
 tasks:
   # Conversion of fakes_src [afw.table] to fakes_source [Parquet]
-  writeSourceTableWithFakes:
+  writeSourceTable:
     class: lsst.pipe.tasks.postprocess.WriteSourceTableTask
     config:
       connections.catalogType: parameters.fakesType
   # TODO: TransformSourceTableTask can't be run until we create a functor
   # config that doesn't depend on shapeHSM.
   # Merging of fakes_source [detector-level] to fakes_sourceTable_visit [visit-level]
-  consolidateSourceTableWithFakes:
+  consolidateSourceTable:
     class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
     config:
       connections.catalogType: parameters.fakesType
@@ -27,7 +27,7 @@ tasks:
       connections.inputCatalogs: "{catalogType}source"
 
   # Merging of fakes_*Diff_diaSrcTable [detector-level Parquet] to fakes_diaSourceTable [visit-level]
-  consolidateDiaSourceTableWithFakes:
+  consolidateDiaSourceTable:
     class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
     config:
       # Task doesn't support coaddName, so coopt catalogType instead.
@@ -38,7 +38,7 @@ tasks:
       connections.outputCatalog: fakes_diaSourceTable
 
   # Creation of fakes_visitSummary
-  consolidateVisitSummaryWithFakes:
+  consolidateVisitSummary:
     class: lsst.pipe.tasks.postprocess.ConsolidateVisitSummaryTask
     config:
       connections.calexpType: parameters.fakesType

--- a/pipelines/_ingredients/MetricsRuntime.yaml
+++ b/pipelines/_ingredients/MetricsRuntime.yaml
@@ -1,8 +1,5 @@
 # Timing and system resource metrics for Alert Production
 
-# Note that some of these configs must be overridden in ApVerifyWithFakes.yaml,
-# because some task names differ from ApVerify.yaml.
-
 description: Runtime metrics (customized for AP pipeline)
 tasks:
   timing_isr:


### PR DESCRIPTION
This PR removes all unnecessary without-fakes processing from `ApVerifyWithFakes`, and moves all metrics that are better measured without fakes to `ApVerify`. With no more need to disambiguate, it also removes the `WithFakes` suffix from individual tasks in `ApVerifyWithFakes`.

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [X] Is the Sphinx documentation up-to-date?
