### PR TITLE
DM-43196: Fix Fakes pipelines to point to correct ProcessCcd

### DIFF
--- a/pipelines/DECam/ApVerifyWithFakes.yaml
+++ b/pipelines/DECam/ApVerifyWithFakes.yaml
@@ -10,7 +10,9 @@ imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ApVerifyWithFakes.yaml
     exclude:
       - processCcd
-  - location: $AP_PIPE_DIR/pipelines/DECam/ProcessCcd.yaml
+  # The existing Fakes insertion system is not currently compatible with the
+  # new CalibrateImageTask, so the fakes pipeline still is on the old tasks.
+  - location: $AP_PIPE_DIR/pipelines/DECam/ProcessCcdCalibrate.yaml
   # Can't use $AP_PIPE_DIR/pipelines/DECam/ApPipeWithFakes.yaml here
   # because the changes made by that file and _ingredients/ApVerifyWithFakes.yaml
   # are hard to separate.

--- a/pipelines/HSC/ApVerifyWithFakes.yaml
+++ b/pipelines/HSC/ApVerifyWithFakes.yaml
@@ -7,7 +7,9 @@ imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ApVerifyWithFakes.yaml
     exclude:
       - processCcd
-  - location: $AP_PIPE_DIR/pipelines/HSC/ProcessCcd.yaml
+  # The existing Fakes insertion system is not currently compatible with the
+  # new CalibrateImageTask, so the fakes pipeline still is on the old tasks.
+  - location: $AP_PIPE_DIR/pipelines/HSC/ProcessCcdCalibrate.yaml
   # Can't use $AP_PIPE_DIR/pipelines/HSC/ApPipeWithFakes.yaml here
   # because the changes made by that file and _ingredients/ApVerifyWithFakes.yaml
   # are hard to separate.

--- a/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
@@ -7,7 +7,9 @@ imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ApVerifyWithFakes.yaml
     exclude:
       - processCcd
-  - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ProcessCcd.yaml
+  # The existing Fakes insertion system is not currently compatible with the
+  # new CalibrateImageTask, so the fakes pipeline still is on the old tasks.
+  - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ProcessCcdCalibrate.yaml
   # Can't use $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml here
   # because the changes made by that file and _ingredients/ApVerifyWithFakes.yaml
   # are hard to separate.


### PR DESCRIPTION
{Summary of changes. Prefix PR title with JIRA issue.}

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [X] Is the Sphinx documentation up-to-date?
