### PR TITLE
DM-40400: Create total AP pipeline timing metric

### DIFF
--- a/pipelines/_ingredients/MetricsRuntime.yaml
+++ b/pipelines/_ingredients/MetricsRuntime.yaml
@@ -267,3 +267,12 @@ tasks:
       connections.metric: PackageAlertsMemory
       connections.labelName: diaPipe
       target: diaPipe:alertPackager.run
+  timing_apPipe:
+    class: lsst.ap.pipe.metrics.PipelineTimingMetricTask
+    config:
+      connections.package: ap_pipe
+      connections.metric: ApPipelineTime
+      connections.labelStart: isr
+      connections.labelEnd: diaPipe
+      targetStart: isr.run
+      targetEnd: diaPipe.run


### PR DESCRIPTION
This PR adds the timing metric introduced on lsst/ap_pipe#168 to the standard runtime metrics for `ApVerify`. Like all timing metrics, it is not run on `ApVerifyWithFakes`.

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ ] Is the Sphinx documentation up-to-date?
