### PR TITLE
DM-41108: add associated diaSources to diaPipe output

### DIFF
--- a/pipelines/_ingredients/MetricsRuntime.yaml
+++ b/pipelines/_ingredients/MetricsRuntime.yaml
@@ -273,6 +273,6 @@ tasks:
       connections.package: ap_pipe
       connections.metric: ApPipelineTime
       connections.labelStart: isr
-      connections.labelEnd: diaPipe
+      connections.labelEnd: analyzeTrailedDiaSrcCore
       targetStart: isr.run
-      targetEnd: diaPipe.run
+      targetEnd: analyzeTrailedDiaSrcCore.run

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -128,6 +128,8 @@ class MockTaskTestSuite(unittest.TestCase):
         butlerTests.addDatasetType(cls.repo, "deepDiff_assocDiaSrc", cls.visitId.dimensions, "DataFrame")
         butlerTests.addDatasetType(cls.repo, "deepDiff_longTrailedSrc", cls.visitId.dimensions, "DataFrame")
         butlerTests.addDatasetType(cls.repo, "deepRealBogusSources", cls.visitId.dimensions, "Catalog")
+        butlerTests.addDatasetType(cls.repo, "deepDiff_diaForcedSrc", cls.visitId.dimensions, "DataFrame")
+        butlerTests.addDatasetType(cls.repo, "deepDiff_diaObject", cls.visitId.dimensions, "DataFrame")
 
     def setUp(self):
         super().setUp()
@@ -324,6 +326,8 @@ class MockTaskTestSuite(unittest.TestCase):
              "apdbMarker": self.visitId,
              "associatedDiaSources": self.visitId,
              "longTrailedSources": self.visitId,
+             "diaForcedSources": self.visitId,
+             "diaObjects": self.visitId,
              })
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 


### PR DESCRIPTION
- updates the unit tests to account for changing doWriteAssociatedSources to True in diaPipe.
- ap_pipe now includes analysis_tools metrics, so make sure they only show up in the ap_verify pipelines once.

****

- [ x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [ x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x ] Is the Sphinx documentation up-to-date?
