### PR TITLE
DM-30267: Produce three-stamp alerts

### DIFF
--- a/pipelines/DECam/ApVerify.yaml
+++ b/pipelines/DECam/ApVerify.yaml
@@ -15,3 +15,4 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True
+      alertPackager.doWriteAlerts: True

--- a/pipelines/HSC/ApVerify.yaml
+++ b/pipelines/HSC/ApVerify.yaml
@@ -15,3 +15,4 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True
+      alertPackager.doWriteAlerts: True

--- a/pipelines/LSSTCam-imSim/ApVerify.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerify.yaml
@@ -15,3 +15,4 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True
+      alertPackager.doWriteAlerts: True

--- a/pipelines/_ingredients/ApVerify.yaml
+++ b/pipelines/_ingredients/ApVerify.yaml
@@ -18,3 +18,4 @@ tasks:
       # TODO: needed for "providing bulk sample alerts to brokers"; remove once
       # we have an alternative.
       doPackageAlerts: True
+      alertPackager.doWriteAlerts: True


### PR DESCRIPTION
Config overrides so alerts are written to disk during CI.

****

- [ X ] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [ X ] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ X ] Is the Sphinx documentation up-to-date?
