### PR TITLE
DM-43404: Add summaryMetrics to detectAndMeasure output

### DIFF
--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -26,7 +26,7 @@
 # to be public for that.
 __all__ = []
 
-
+import astropy.table
 import numpy as np
 import pandas
 
@@ -432,6 +432,7 @@ class MockDetectAndMeasureTask(PipelineTask):
         """
         return Struct(subtractedMeasuredExposure=difference,
                       diaSources=afwTable.SourceCatalog(),
+                      spatiallySampledMetrics=astropy.table.Table(),
                       )
 
 

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -121,6 +121,8 @@ class MockTaskTestSuite(unittest.TestCase):
         butlerTests.addDatasetType(cls.repo, "deepDiff_matchedExp", cls.visitId.dimensions, "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_diaSrc", cls.visitId.dimensions, "SourceCatalog")
         butlerTests.addDatasetType(cls.repo, "deepDiff_diaSrcTable", cls.visitId.dimensions, "DataFrame")
+        butlerTests.addDatasetType(cls.repo, "deepDiff_spatiallySampledMetrics", cls.visitId.dimensions,
+                                   "ArrowAstropy")
         butlerTests.addDatasetType(cls.repo, "deepDiff_candidateDiaSrc", cls.visitId.dimensions,
                                    "SourceCatalog")
         butlerTests.addDatasetType(cls.repo, "visitSsObjects", cls.visitOnlyId.dimensions, "DataFrame")
@@ -252,6 +254,7 @@ class MockTaskTestSuite(unittest.TestCase):
              "difference": self.visitId,
              "diaSources": self.visitId,
              "subtractedMeasuredExposure": self.visitId,
+             "spatiallySampledMetrics": self.visitId,
              })
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 


### PR DESCRIPTION
{Summary of changes. Prefix PR title with JIRA issue.}

****

- [ x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [ x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ x] Is the Sphinx documentation up-to-date?
