### PR TITLE
DM-43736: Add PSF matching kernel dataset to mock pipeline

### DIFF
--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -119,6 +119,8 @@ class MockTaskTestSuite(unittest.TestCase):
         butlerTests.addDatasetType(cls.repo, "deepDiff_templateExp", cls.visitId.dimensions, "ExposureF")
         butlerTests.addDatasetType(cls.repo, "goodSeeingDiff_templateExp", cls.visitId.dimensions,
                                    "ExposureF")
+        butlerTests.addDatasetType(cls.repo, "deepDiff_psfMatchKernel", cls.visitId.dimensions,
+                                   "MatchingKernel")
         butlerTests.addDatasetType(cls.repo, "deepDiff_matchedExp", cls.visitId.dimensions, "ExposureF")
         butlerTests.addDatasetType(cls.repo, "deepDiff_diaSrc", cls.visitId.dimensions, "SourceCatalog")
         butlerTests.addDatasetType(cls.repo, "deepDiff_diaSrcTable", cls.visitId.dimensions, "DataFrame")
@@ -232,6 +234,7 @@ class MockTaskTestSuite(unittest.TestCase):
              "sources": self.visitId,
              "difference": self.visitId,
              "matchedTemplate": self.visitId,
+             "psfMatchingKernel": self.visitId,
              })
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 


### PR DESCRIPTION
{Summary of changes. Prefix PR title with JIRA issue.}

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x] Is the Sphinx documentation up-to-date?
