### PR TITLE
DM-43848: Add tests to reflect the new spatially sampled metric Task

### DIFF
--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -38,7 +38,8 @@ from lsst.ap.association import (TransformDiaSourceCatalogConfig,
                                  DiaPipelineConfig, FilterDiaSourceCatalogConfig)
 from lsst.pipe.base import PipelineTask, Struct
 from lsst.ip.isr import IsrTaskConfig
-from lsst.ip.diffim import GetTemplateConfig, AlardLuptonSubtractConfig, DetectAndMeasureConfig
+from lsst.ip.diffim import (GetTemplateConfig, AlardLuptonSubtractConfig,
+                            DetectAndMeasureConfig, SpatiallySampledMetricsConfig)
 from lsst.pipe.tasks.characterizeImage import CharacterizeImageConfig
 from lsst.pipe.tasks.calibrate import CalibrateConfig
 from lsst.meas.transiNet import RBTransiNetConfig
@@ -432,7 +433,6 @@ class MockDetectAndMeasureTask(PipelineTask):
         """
         return Struct(subtractedMeasuredExposure=difference,
                       diaSources=afwTable.SourceCatalog(),
-                      spatiallySampledMetrics=astropy.table.Table(),
                       )
 
 
@@ -458,6 +458,39 @@ class MockFilterDiaSourceCatalogTask(PipelineTask):
         return Struct(filteredDiaSourceCat=afwTable.SourceCatalog(),
                       rejectedDiaSources=afwTable.SourceCatalog(),
                       )
+
+
+class MockSpatiallySampledMetricsTask(PipelineTask):
+    """A do-nothing substitute for SpatiallySampledMetricsTask.
+    """
+    ConfigClass = SpatiallySampledMetricsConfig
+    _DefaultName = "notSpatiallySampledMetricsTask"
+
+    def run(self, science, matchedTemplate, template, difference, diaSources):
+        """Produce spatially sampled metrics
+
+        Parameters
+        ----------
+        science : `lsst.afw.image.ExposureF`
+            Science exposure that the template was subtracted from.
+        matchedTemplate : `lsst.afw.image.ExposureF`
+            Warped and PSF-matched template that was used produce the
+            difference image.
+        template : `lsst.afw.image.ExposureF`
+            Warped and non PSF-matched template that was used to produce
+            the difference image.
+        difference : `lsst.afw.image.ExposureF`
+            Result of subtracting template from the science image.
+        diaSources : `lsst.afw.table.SourceCatalog`
+                The catalog of detected sources.
+
+        Returns
+        -------
+        results : `lsst.pipe.base.Struct`
+            Results struct with components.
+        """
+
+        return Struct(spatiallySampledMetrics=astropy.table.Table())
 
 
 class MockRBTransiNetTask(PipelineTask):

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -38,7 +38,8 @@ import lsst.pipe.base.testUtils as pipelineTests
 from lsst.ap.verify.testPipeline import MockIsrTask, MockCharacterizeImageTask, \
     MockCalibrateTask, MockGetTemplateTask, \
     MockAlardLuptonSubtractTask, MockDetectAndMeasureTask, MockTransformDiaSourceCatalogTask, \
-    MockRBTransiNetTask, MockDiaPipelineTask, MockFilterDiaSourceCatalogTask
+    MockRBTransiNetTask, MockDiaPipelineTask, MockFilterDiaSourceCatalogTask, \
+    MockSpatiallySampledMetricsTask
 
 
 class MockTaskTestSuite(unittest.TestCase):
@@ -254,7 +255,6 @@ class MockTaskTestSuite(unittest.TestCase):
              "difference": self.visitId,
              "diaSources": self.visitId,
              "subtractedMeasuredExposure": self.visitId,
-             "spatiallySampledMetrics": self.visitId,
              })
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 
@@ -263,6 +263,33 @@ class MockTaskTestSuite(unittest.TestCase):
         pipelineTests.assertValidInitOutput(task)
         result = task.run(afwTable.SourceCatalog())
         pipelineTests.assertValidOutput(task, result)
+
+    def testMockSpatiallySampledMetricsTask(self):
+        task = MockSpatiallySampledMetricsTask()
+        result = task.run(
+            afwImage.ExposureF(),
+            afwImage.ExposureF(),
+            afwImage.ExposureF(),
+            afwImage.ExposureF(),
+            afwTable.SourceCatalog(),
+        )
+        pipelineTests.assertValidOutput(task, result)
+
+        self.butler.put(afwImage.ExposureF(), "calexp", self.visitId)
+        self.butler.put(afwImage.ExposureF(), "deepDiff_matchedExp", self.visitId)
+        self.butler.put(afwImage.ExposureF(), "deepDiff_templateExp", self.visitId)
+        self.butler.put(afwImage.ExposureF(), "deepDiff_differenceExp", self.visitId)
+        self.butler.put(afwTable.SourceCatalog(), "deepDiff_candidateDiaSrc", self.visitId)
+        quantum = pipelineTests.makeQuantum(
+            task, self.butler, self.visitId,
+            {"science": self.visitId,
+             "matchedTemplate": self.visitId,
+             "template": self.visitId,
+             "difference": self.visitId,
+             "diaSources": self.visitId,
+             "spatiallySampledMetrics": self.visitId,
+             })
+        pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 
     def testMockRBTransiNetTask(self):
         task = MockRBTransiNetTask()


### PR DESCRIPTION
Move spatiallySampledMetrics out of the connections for detectAndMeasure, and add the new pipelineTask that computes them.

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x] Is the Sphinx documentation up-to-date?
