### PR TITLE
DM-41063: Remove trailedSourceFilter and add to filterDiaSourceCatalog

### DIFF
--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -442,22 +442,33 @@ class MockFilterDiaSourceCatalogTask(PipelineTask):
     ConfigClass = FilterDiaSourceCatalogConfig
     _DefaultName = "notFilterDiaSourceCatalog"
 
-    def run(self, diaSourceCat):
+    def run(self, diaSourceCat, diffImVisitInfo):
         """Produce filtering outputs with no processing.
 
         Parameters
         ----------
         diaSourceCat : `lsst.afw.table.SourceCatalog`
             Catalog of sources measured on the difference image.
+        diffImVisitInfo:  `lsst.afw.image.VisitInfo`
+            VisitInfo for the difference image corresponding to diaSourceCat.
 
         Returns
         -------
         results : `lsst.pipe.base.Struct`
             Results struct with components.
+
+            ``filteredDiaSourceCat`` : `lsst.afw.table.SourceCatalog`
+                The catalog of filtered sources.
+            ``rejectedDiaSources`` : `lsst.afw.table.SourceCatalog`
+                The catalog of rejected sky sources.
+            ``longTrailedDiaSources`` : `astropy.table.Table`
+                DiaSources which have trail lengths greater than
+                max_trail_length*exposure_time.
         """
+        # TODO Add docstrings for diffIm
         return Struct(filteredDiaSourceCat=afwTable.SourceCatalog(),
                       rejectedDiaSources=afwTable.SourceCatalog(),
-                      longTrailedSources=afwTable.SourceCatalog(),
+                      longTrailedSources=afwTable.SourceCatalog().asAstropy(),
                       )
 
 

--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -457,6 +457,7 @@ class MockFilterDiaSourceCatalogTask(PipelineTask):
         """
         return Struct(filteredDiaSourceCat=afwTable.SourceCatalog(),
                       rejectedDiaSources=afwTable.SourceCatalog(),
+                      longTrailedSources=afwTable.SourceCatalog(),
                       )
 
 
@@ -631,6 +632,4 @@ class MockDiaPipelineTask(PipelineTask):
         return Struct(apdbMarker=self.config.apdb.value,
                       associatedDiaSources=pandas.DataFrame(),
                       diaForcedSources=pandas.DataFrame(),
-                      diaObjects=pandas.DataFrame(),
-                      longTrailedSources=pandas.DataFrame(),
-                      )
+                      diaObjects=pandas.DataFrame(),)

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -263,9 +263,10 @@ class MockTaskTestSuite(unittest.TestCase):
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)
 
     def testMockFilterDiaSourceCatalogTask(self):
+        visitInfo = afwImage.VisitInfo()
         task = MockFilterDiaSourceCatalogTask()
         pipelineTests.assertValidInitOutput(task)
-        result = task.run(afwTable.SourceCatalog())
+        result = task.run(afwTable.SourceCatalog(), visitInfo)
         pipelineTests.assertValidOutput(task, result)
 
     def testMockSpatiallySampledMetricsTask(self):

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -131,7 +131,8 @@ class MockTaskTestSuite(unittest.TestCase):
         butlerTests.addDatasetType(cls.repo, "visitSsObjects", cls.visitOnlyId.dimensions, "DataFrame")
         butlerTests.addDatasetType(cls.repo, "apdb_marker", cls.visitId.dimensions, "Config")
         butlerTests.addDatasetType(cls.repo, "deepDiff_assocDiaSrc", cls.visitId.dimensions, "DataFrame")
-        butlerTests.addDatasetType(cls.repo, "deepDiff_longTrailedSrc", cls.visitId.dimensions, "DataFrame")
+        butlerTests.addDatasetType(cls.repo, "deepDiff_longTrailedSrc", cls.visitId.dimensions,
+                                   "ArrowAstropy")
         butlerTests.addDatasetType(cls.repo, "deepRealBogusSources", cls.visitId.dimensions, "Catalog")
         butlerTests.addDatasetType(cls.repo, "deepDiff_diaForcedSrc", cls.visitId.dimensions, "DataFrame")
         butlerTests.addDatasetType(cls.repo, "deepDiff_diaObject", cls.visitId.dimensions, "DataFrame")
@@ -359,7 +360,6 @@ class MockTaskTestSuite(unittest.TestCase):
              "template": self.visitId,
              "apdbMarker": self.visitId,
              "associatedDiaSources": self.visitId,
-             "longTrailedSources": self.visitId,
              "diaForcedSources": self.visitId,
              "diaObjects": self.visitId,
              })


### PR DESCRIPTION
Remove longTrailedSources from `diaPipe`, change its output to `ArrowAstropy`, and add longTrailedSources to output from `filteredDiaSourceCatalog`
****

- [ x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [ x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ ] Is the Sphinx documentation up-to-date?
