### PR TITLE
DM-42435: Migrate DM schemas from ccdVisitId to (visit, detector)

### DIFF
--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -514,15 +514,15 @@ class MockTransformDiaSourceCatalogTask(PipelineTask):
 
     def runQuantum(self, butlerQC, inputRefs, outputRefs):
         inputs = butlerQC.get(inputRefs)
-        idGenerator = self.config.idGenerator.apply(butlerQC.quantum.dataId)
-        inputs["ccdVisitId"] = idGenerator.catalog_id
         inputs["band"] = butlerQC.quantum.dataId["band"]
+        inputs["visit"] = butlerQC.quantum.dataId["visit"]
+        inputs["detector"] = butlerQC.quantum.dataId["detector"]
 
         outputs = self.run(**inputs)
 
         butlerQC.put(outputs, outputRefs)
 
-    def run(self, diaSourceCat, diffIm, band, ccdVisitId, funcs=None):
+    def run(self, diaSourceCat, diffIm, band, visit, detector, funcs=None):
         """Produce transformation outputs with no processing.
 
         Parameters
@@ -533,8 +533,8 @@ class MockTransformDiaSourceCatalogTask(PipelineTask):
             An image, to provide supplementary information.
         band : `str`
             The band in which the sources were observed.
-        ccdVisitId : `int`
-            The exposure ID in which the sources were observed.
+        visit, detector: `int`
+            Visit and detector the sources were detected on.
         funcs, optional
             Unused.
 

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -322,7 +322,7 @@ class MockTaskTestSuite(unittest.TestCase):
     def testMockTransformDiaSourceCatalogTask(self):
         task = MockTransformDiaSourceCatalogTask(initInputs=afwTable.SourceCatalog())
         pipelineTests.assertValidInitOutput(task)
-        result = task.run(afwTable.SourceCatalog(), afwImage.ExposureF(), 'k', 42)
+        result = task.run(afwTable.SourceCatalog(), afwImage.ExposureF(), 'k', 42, 2)
         pipelineTests.assertValidOutput(task, result)
 
         self.butler.put(afwTable.SourceCatalog(), "deepDiff_candidateDiaSrc", self.visitId)


### PR DESCRIPTION
{Summary of changes. Prefix PR title with JIRA issue.}

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x] Is the Sphinx documentation up-to-date?
