### PR TITLE
DM-43416: Migrate AP code to external APDB configs

### DIFF
--- a/doc/lsst.ap.verify/index.rst
+++ b/doc/lsst.ap.verify/index.rst
@@ -32,7 +32,7 @@ Contributing
 ============
 
 ``lsst.ap.verify`` is developed at https://github.com/lsst/ap_verify.
-You can find Jira issues for this module under the `ap_verify <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ap_verify>`_ component.
+You can find Jira issues for this module under the `ap_verify <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20ap_verify>`_ component.
 
 .. _lsst.ap.verify-pyapi:
 

--- a/pipelines/DECam/ApVerify.yaml
+++ b/pipelines/DECam/ApVerify.yaml
@@ -16,3 +16,8 @@ tasks:
     config:
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
+contracts:
+  # Contracts removed by excluding apPipe
+  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
+    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
+  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)

--- a/pipelines/DECam/ApVerifyCalibrate.yaml
+++ b/pipelines/DECam/ApVerifyCalibrate.yaml
@@ -18,6 +18,9 @@ tasks:
 contracts:
   # Must re-declare contracts that cross apPipe and metrics boundary, as
   # these were removed on import.
+  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
+    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
+  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
       fracDiaSourcesToSciSources.connections.ConnectionsClass(config=fracDiaSourcesToSciSources).diaSources.name

--- a/pipelines/HSC/ApVerify.yaml
+++ b/pipelines/HSC/ApVerify.yaml
@@ -16,3 +16,8 @@ tasks:
     config:
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
+contracts:
+  # Contracts removed by excluding apPipe
+  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
+    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
+  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)

--- a/pipelines/HSC/ApVerifyCalibrate.yaml
+++ b/pipelines/HSC/ApVerifyCalibrate.yaml
@@ -15,3 +15,8 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True
+contracts:
+  # Contracts removed by excluding apPipe
+  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
+    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
+  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)

--- a/pipelines/LSSTCam-imSim/ApVerify.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerify.yaml
@@ -16,3 +16,8 @@ tasks:
     config:
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
+contracts:
+  # Contracts removed by excluding apPipe
+  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
+    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
+  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)

--- a/pipelines/LSSTCam-imSim/ApVerifyCalibrate.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerifyCalibrate.yaml
@@ -18,6 +18,9 @@ tasks:
 contracts:
   # Must re-declare contracts that cross apPipe and metrics boundary, as
   # these were removed on import.
+  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
+    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
+  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==
       fracDiaSourcesToSciSources.connections.ConnectionsClass(config=fracDiaSourcesToSciSources).diaSources.name

--- a/pipelines/_ingredients/ApVerify.yaml
+++ b/pipelines/_ingredients/ApVerify.yaml
@@ -19,3 +19,7 @@ tasks:
       # we have an alternative.
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
+contracts:
+  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
+    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
+  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)

--- a/pipelines/_ingredients/ApVerifyCalibrate.yaml
+++ b/pipelines/_ingredients/ApVerifyCalibrate.yaml
@@ -19,6 +19,9 @@ tasks:
       # we have an alternative.
       doPackageAlerts: True
 contracts:
+  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
+    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
+  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)
   # Metric inputs must match pipeline outputs
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210
   - detectAndMeasure.connections.ConnectionsClass(config=detectAndMeasure).diaSources.name ==

--- a/pipelines/_ingredients/MetricsMisc.yaml
+++ b/pipelines/_ingredients/MetricsMisc.yaml
@@ -25,3 +25,6 @@ tasks:
       connections.labelName: diaPipe
   totalUnassociatedDiaObjects:
     class: lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask
+    config:
+        doReadMarker: False  # Impossible if diaPipe uses new-style config
+        apdb_config_url: parameters.apdb_config

--- a/pipelines/_ingredients/MetricsMiscCalibrate.yaml
+++ b/pipelines/_ingredients/MetricsMiscCalibrate.yaml
@@ -26,6 +26,9 @@ tasks:
       connections.labelName: diaPipe
   totalUnassociatedDiaObjects:
     class: lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask
+    config:
+        doReadMarker: False  # Impossible if diaPipe uses new-style config
+        apdb_config_url: parameters.apdb_config
   numSciSources:
     class: lsst.ip.diffim.metrics.NumberSciSourcesMetricTask
   fracDiaSourcesToSciSources:

--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -116,6 +116,15 @@ class Workspace(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
+    def dbConfigLocation(self):
+        """The absolute location of the config file for the source association
+        database to be created or updated by the pipeline (`str`, read-only).
+
+        The location is assumed to be a Python (`lsst.pex.config.Config`) file.
+        """
+
+    @property
+    @abc.abstractmethod
     def alertLocation(self):
         """The absolute location of an output directory for persisted
         alert packets (`str`, read-only).
@@ -188,6 +197,10 @@ class WorkspaceGen3(Workspace):
     @property
     def dbLocation(self):
         return os.path.join(self._location, 'association.db')
+
+    @property
+    def dbConfigLocation(self):
+        return os.path.join(self._location, 'apdb.py')
 
     @property
     def alertLocation(self):

--- a/tests/MockApPipe.yaml
+++ b/tests/MockApPipe.yaml
@@ -5,6 +5,7 @@ parameters:
   coaddName: goodSeeing
   # only refcat in ap_verify_testdata
   refcat: gaia
+  apdb_config: dummy_path.yaml
 tasks:
   isr:
     class: lsst.ap.verify.testPipeline.MockIsrTask
@@ -54,6 +55,8 @@ tasks:
     class: lsst.ap.verify.testPipeline.MockDiaPipelineTask
     config:
       doWriteAssociatedSources: True
+      doConfigureApdb: False
+      apdb_config_url: parameters.apdb_config
       connections.coaddName: parameters.coaddName
 contracts:
   # Inputs and outputs must match

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -337,7 +337,8 @@ class MockTaskTestSuite(unittest.TestCase):
 
     def testMockDiaPipelineTask(self):
         config = MockDiaPipelineTask.ConfigClass()
-        config.apdb.db_url = "testing_only"
+        config.doConfigureApdb = False
+        config.apdb_config_url = "testing_only"
         task = MockDiaPipelineTask(config=config)
         pipelineTests.assertValidInitOutput(task)
         result = task.run(pandas.DataFrame(), pandas.DataFrame(), afwImage.ExposureF(),

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -106,6 +106,15 @@ class WorkspaceGen3TestSuite(lsst.utils.tests.TestCase):
         # Workspace spec allows these to be URIs or paths, whatever the Butler accepts
         self._assertNotInDir(self._testbed.dbLocation, url2pathname(self._testbed.repo))
 
+    def testDbConfig(self):
+        """Verify that a WorkspaceGen3 requests a database config in the target
+        directory, but not in any repository.
+        """
+        root = self._testWorkspace
+        self._assertInDir(self._testbed.dbConfigLocation, root)
+        # Workspace spec allows these to be URIs or paths, whatever the Butler accepts
+        self._assertNotInDir(self._testbed.dbConfigLocation, url2pathname(self._testbed.repo))
+
     def testAlerts(self):
         """Verify that a WorkspaceGen3 requests an alert dump in the target
         directory, but not in any repository.


### PR DESCRIPTION
This PR modifies the `ap_verify` framework and the metrics pipelines to use new-style configs instead of handling `ApdbConfig` objects directly. It must be merged after lsst/ap_association#210 and lsst/verify#124.

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.