### PR TITLE
DM-43849: Create spatiallySampledMetric to visualize the diffim kernel

### DIFF
--- a/python/lsst/ap/verify/testPipeline.py
+++ b/python/lsst/ap/verify/testPipeline.py
@@ -478,7 +478,7 @@ class MockSpatiallySampledMetricsTask(PipelineTask):
     ConfigClass = SpatiallySampledMetricsConfig
     _DefaultName = "notSpatiallySampledMetricsTask"
 
-    def run(self, science, matchedTemplate, template, difference, diaSources):
+    def run(self, science, matchedTemplate, template, difference, diaSources, psfMatchingKernel):
         """Produce spatially sampled metrics
 
         Parameters
@@ -495,6 +495,8 @@ class MockSpatiallySampledMetricsTask(PipelineTask):
             Result of subtracting template from the science image.
         diaSources : `lsst.afw.table.SourceCatalog`
                 The catalog of detected sources.
+        psfMatchingKernel : `~lsst.afw.math.LinearCombinationKernel`
+            The PSF matching kernel of the subtraction to evaluate.
 
         Returns
         -------

--- a/tests/test_testPipeline.py
+++ b/tests/test_testPipeline.py
@@ -277,6 +277,7 @@ class MockTaskTestSuite(unittest.TestCase):
             afwImage.ExposureF(),
             afwImage.ExposureF(),
             afwTable.SourceCatalog(),
+            afwMath.LinearCombinationKernel(),
         )
         pipelineTests.assertValidOutput(task, result)
 
@@ -285,6 +286,7 @@ class MockTaskTestSuite(unittest.TestCase):
         self.butler.put(afwImage.ExposureF(), "deepDiff_templateExp", self.visitId)
         self.butler.put(afwImage.ExposureF(), "deepDiff_differenceExp", self.visitId)
         self.butler.put(afwTable.SourceCatalog(), "deepDiff_candidateDiaSrc", self.visitId)
+        self.butler.put(afwMath.LinearCombinationKernel(), "deepDiff_psfMatchKernel", self.visitId)
         quantum = pipelineTests.makeQuantum(
             task, self.butler, self.visitId,
             {"science": self.visitId,
@@ -292,6 +294,7 @@ class MockTaskTestSuite(unittest.TestCase):
              "template": self.visitId,
              "difference": self.visitId,
              "diaSources": self.visitId,
+             "psfMatchingKernel": self.visitId,
              "spatiallySampledMetrics": self.visitId,
              })
         pipelineTests.runTestQuantum(task, self.butler, quantum, mockRun=False)


### PR DESCRIPTION
Fixing pipeline tests to reflect changes in spatially sampled metrics
****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x] Is the Sphinx documentation up-to-date?
