### PR TITLE
DM-45209: Fix E721 lint warning (type comparison)

### DIFF
--- a/python/lsst/ap/verify/workspace.py
+++ b/python/lsst/ap/verify/workspace.py
@@ -84,7 +84,7 @@ class Workspace(metaclass=abc.ABCMeta):
         """Test whether two workspaces are of the same type and have the
         same location.
         """
-        return type(self) == type(other) and self.workDir == other.workDir
+        return type(self) is type(other) and self.workDir == other.workDir
 
     def __repr__(self):
         """A string representation that can be used to reconstruct the Workspace.


### PR DESCRIPTION
{Summary of changes. Prefix PR title with JIRA issue.}

****

- [ ] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [ ] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ ] Is the Sphinx documentation up-to-date?
