### PR TITLE
DM-43418: Fixes to ApVerify pipelines

### DIFF
--- a/pipelines/DECam/ApVerifyWithFakes.yaml
+++ b/pipelines/DECam/ApVerifyWithFakes.yaml
@@ -8,3 +8,31 @@ instrument: lsst.obs.decam.DarkEnergyCamera
 description: Fully instrumented AP pipeline with fakes, specialized for DECam
 imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ApVerifyWithFakes.yaml
+    # Include all metrics from standard pipeline. It's not practical to create
+    # a metrics subset because it would require constant micromanagement.
+    exclude:
+      - apPipe
+  - location: $AP_PIPE_DIR/pipelines/DECam/ApPipeWithFakes.yaml
+tasks:
+  # ApVerify override removed by excluding apPipe.
+  diaPipe:
+    class: lsst.ap.association.DiaPipelineTask
+    config:
+      doPackageAlerts: True
+      alertPackager.doWriteAlerts: True
+contracts:
+  # Contracts removed by excluding apPipe
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCompletenessMag20t22.connections.ConnectionsClass(config=apFakesCompletenessMag20t22).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCompletenessMag22t24.connections.ConnectionsClass(config=apFakesCompletenessMag22t24).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCompletenessMag24t26.connections.ConnectionsClass(config=apFakesCompletenessMag24t26).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCountMag20t22.connections.ConnectionsClass(config=apFakesCountMag20t22).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCountMag22t24.connections.ConnectionsClass(config=apFakesCountMag22t24).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCountMag24t26.connections.ConnectionsClass(config=apFakesCountMag24t26).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCount.connections.ConnectionsClass(config=apFakesCount).matchedFakes.name

--- a/pipelines/HSC/ApVerifyWithFakes.yaml
+++ b/pipelines/HSC/ApVerifyWithFakes.yaml
@@ -1,7 +1,35 @@
-# Verification pipeline specialized for HSC, with fak source injection.
+# Verification pipeline specialized for HSC, with fake source injection.
 # This concatenates various lsst.verify metrics to an AP pipeline
 
 instrument: lsst.obs.subaru.HyperSuprimeCam
 description: Fully instrumented AP pipeline with fakes, specialized for HSC
 imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ApVerifyWithFakes.yaml
+    # Include all metrics from standard pipeline. It's not practical to create
+    # a metrics subset because it would require constant micromanagement.
+    exclude:
+      - apPipe
+  - location: $AP_PIPE_DIR/pipelines/HSC/ApPipeWithFakes.yaml
+tasks:
+  # ApVerify override removed by excluding apPipe.
+  diaPipe:
+    class: lsst.ap.association.DiaPipelineTask
+    config:
+      doPackageAlerts: True
+      alertPackager.doWriteAlerts: True
+contracts:
+  # Contracts removed by excluding apPipe
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCompletenessMag20t22.connections.ConnectionsClass(config=apFakesCompletenessMag20t22).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCompletenessMag22t24.connections.ConnectionsClass(config=apFakesCompletenessMag22t24).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCompletenessMag24t26.connections.ConnectionsClass(config=apFakesCompletenessMag24t26).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCountMag20t22.connections.ConnectionsClass(config=apFakesCountMag20t22).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCountMag22t24.connections.ConnectionsClass(config=apFakesCountMag22t24).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCountMag24t26.connections.ConnectionsClass(config=apFakesCountMag24t26).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCount.connections.ConnectionsClass(config=apFakesCount).matchedFakes.name

--- a/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
@@ -5,3 +5,31 @@ instrument: lsst.obs.lsst.LsstCamImSim
 description: Fully instrumented AP pipeline with fakes, specialized for LSSTCam-imSim
 imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ApVerifyWithFakes.yaml
+    # Include all metrics from standard pipeline. It's not practical to create
+    # a metrics subset because it would require constant micromanagement.
+    exclude:
+      - apPipe
+  - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml
+tasks:
+  # ApVerify override removed by excluding apPipe.
+  diaPipe:
+    class: lsst.ap.association.DiaPipelineTask
+    config:
+      doPackageAlerts: True
+      alertPackager.doWriteAlerts: True
+contracts:
+  # Contracts removed by excluding apPipe
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCompletenessMag20t22.connections.ConnectionsClass(config=apFakesCompletenessMag20t22).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCompletenessMag22t24.connections.ConnectionsClass(config=apFakesCompletenessMag22t24).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCompletenessMag24t26.connections.ConnectionsClass(config=apFakesCompletenessMag24t26).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCountMag20t22.connections.ConnectionsClass(config=apFakesCountMag20t22).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCountMag22t24.connections.ConnectionsClass(config=apFakesCountMag22t24).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCountMag24t26.connections.ConnectionsClass(config=apFakesCountMag24t26).matchedFakes.name
+  - injectedMatch.connections.ConnectionsClass(config=injectedMatch).matchedDiaSources.name ==
+      apFakesCount.connections.ConnectionsClass(config=apFakesCount).matchedFakes.name

--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -14,6 +14,7 @@ tasks:
       # TODO: needed for "providing bulk sample alerts to brokers"; remove once
       # we have an alternative.
       doPackageAlerts: True
+      alertPackager.doWriteAlerts: True
 contracts:
   # Metric inputs must match pipeline outputs
   # Use of ConnectionsClass for templated fields is a workaround for DM-30210


### PR DESCRIPTION
This PR fixes some consistency issues (including a subtle DECam bug) with `ApVerifyWithFakes`.

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ ] Is the Sphinx documentation up-to-date?
