### PR TITLE
DM-45668: Add --namespace option to ap_verify command line

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -65,7 +65,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    Multiple copies of this argument are allowed.
 
    If this argument is omitted, then all data IDs in the dataset will be processed.
-   
+
 .. option:: --dataset <dataset_package>
 
    **Input dataset package.**
@@ -87,6 +87,13 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
    If this argument is omitted, ``ap_verify`` creates an SQLite database inside the directory indicated by :option:`--output`.
 
+.. option:: --namespace
+
+  **Namespace to use in the target database**
+
+  Takes a namespace string which has is a standard identifier format.
+  Only relevant for Postgres databases, together with ``--db`` option can be used to run ``ap_verify`` against a shared Postgres database.
+
 .. option:: -h, --help
 
    **Print help.**
@@ -98,7 +105,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    **Number of processes to use.**
 
    When ``processes`` is larger than 1 the pipeline may use the Python `multiprocessing` module to parallelize processing of multiple datasets across multiple processors.
-   
+
 .. option:: --output <workspace_dir>
 
    **Output and intermediate product path.**

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -61,6 +61,8 @@ class ApPipeParser(argparse.ArgumentParser):
         self.add_argument("--db", "--db_url", default=None,
                           help="A location for the AP database, formatted as if for apdb-cli create-sql. "
                                "Defaults to an SQLite file in the --output directory.")
+        self.add_argument("--namespace", default=None,
+                          help="Namespace for the AP database.")
         self.add_argument("--skip-pipeline", action="store_true",
                           help="Do not run the AP pipeline itself. This argument is useful "
                                "for testing metrics on a fixed data set.")
@@ -215,8 +217,10 @@ def _getApdbArguments(workspace, parsed):
     if not parsed.db:
         parsed.db = "sqlite:///" + workspace.dbLocation
 
-    args = {"db_url": parsed.db,
-            }
+    args = {
+        "db_url": parsed.db,
+        "namespace": parsed.namespace,
+    }
 
     return args
 


### PR DESCRIPTION
The --namespace option can be used together with --db option to run ap_verify against a shared postgres database.

{Summary of changes. Prefix PR title with JIRA issue.}

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [X] Is the Sphinx documentation up-to-date?
