### PR TITLE
DM-45959: Update timing metrics for LoadDiaCatalogsTask

### DIFF
--- a/pipelines/_ingredients/MetricsRuntime.yaml
+++ b/pipelines/_ingredients/MetricsRuntime.yaml
@@ -90,13 +90,13 @@ tasks:
       connections.metric: MapDiaSourceTime
       connections.labelName: transformDiaSrcCat
       target: transformDiaSrcCat.run
-  timing_diaPipe_diaCatalogLoader:
+  timing_diaCatalogLoader:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: LoadDiaCatalogsTime
-      connections.labelName: diaPipe
-      target: diaPipe:diaCatalogLoader.run
+      connections.labelName: loadDiaCatalogs
+      target: loadDiaCatalogs.run
   timing_diaPipe_associator:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
@@ -211,13 +211,13 @@ tasks:
       connections.metric: MapDiaSourceCpuTime
       connections.labelName: transformDiaSrcCat
       target: transformDiaSrcCat.run
-  cputiming_diaPipe_diaCatalogLoader:
+  cputiming_diaCatalogLoader:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: LoadDiaCatalogsCpuTime
-      connections.labelName: diaPipe
-      target: diaPipe:diaCatalogLoader.run
+      connections.labelName: loadDiaCatalogs
+      target: loadDiaCatalogs.run
   cputiming_diaPipe_associator:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:


### PR DESCRIPTION
{Summary of changes. Prefix PR title with JIRA issue.}

****

- [ x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x ] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x ] Is the Sphinx documentation up-to-date?
