### PR TITLE
DM-45959: Fix incorrect metadata dimensions for *timing_loadDiaCatalogs.

### DIFF
--- a/pipelines/_ingredients/MetricsRuntime.yaml
+++ b/pipelines/_ingredients/MetricsRuntime.yaml
@@ -96,6 +96,7 @@ tasks:
       connections.package: ap_association
       connections.metric: LoadDiaCatalogsTime
       connections.labelName: loadDiaCatalogs
+      metadataDimensions: [instrument, group, detector]  # TimingMetricTask assumes visit
       target: loadDiaCatalogs.run
   timing_diaPipe_associator:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
@@ -217,6 +218,7 @@ tasks:
       connections.package: ap_association
       connections.metric: LoadDiaCatalogsCpuTime
       connections.labelName: loadDiaCatalogs
+      metadataDimensions: [instrument, group, detector]  # CpuTimingMetricTask assumes visit
       target: loadDiaCatalogs.run
   cputiming_diaPipe_associator:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask


### PR DESCRIPTION
This PR fixes a bug introduced in #233 that causes the timing metrics to try to load metadata of the wrong dimensions, causing quantum graph failure.

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ ] Is the Sphinx documentation up-to-date?
