### PR TITLE
DM-45750: Store new-style ephemerides and APDB catalogs in ap_verify data sets

### DIFF
--- a/pipelines/DECam/ApVerify.yaml
+++ b/pipelines/DECam/ApVerify.yaml
@@ -7,8 +7,10 @@ imports:
     # Include all metrics from standard pipeline. It's not practical to create
     # a metrics subset because it would require constant micromanagement.
     exclude:
-      - apPipe
+      - prompt
   - location: $AP_PIPE_DIR/pipelines/DECam/ApPipe.yaml
+    include:
+      - prompt
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/DECam/ApVerifyWithFakes.yaml
+++ b/pipelines/DECam/ApVerifyWithFakes.yaml
@@ -11,8 +11,10 @@ imports:
     # Include all metrics from standard pipeline. It's not practical to create
     # a metrics subset because it would require constant micromanagement.
     exclude:
-      - apPipe
+      - prompt
   - location: $AP_PIPE_DIR/pipelines/DECam/ApPipeWithFakes.yaml
+    include:
+      - prompt
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/HSC/ApVerify.yaml
+++ b/pipelines/HSC/ApVerify.yaml
@@ -7,8 +7,10 @@ imports:
     # Include all metrics from standard pipeline. It's not practical to create
     # a metrics subset because it would require constant micromanagement.
     exclude:
-      - apPipe
+      - prompt
   - location: $AP_PIPE_DIR/pipelines/HSC/ApPipe.yaml
+    include:
+      - prompt
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/HSC/ApVerifyWithFakes.yaml
+++ b/pipelines/HSC/ApVerifyWithFakes.yaml
@@ -8,8 +8,10 @@ imports:
     # Include all metrics from standard pipeline. It's not practical to create
     # a metrics subset because it would require constant micromanagement.
     exclude:
-      - apPipe
+      - prompt
   - location: $AP_PIPE_DIR/pipelines/HSC/ApPipeWithFakes.yaml
+    include:
+      - prompt
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/LSSTCam-imSim/ApVerify.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerify.yaml
@@ -7,8 +7,10 @@ imports:
     # Include all metrics from standard pipeline. It's not practical to create
     # a metrics subset because it would require constant micromanagement.
     exclude:
-      - apPipe
+      - prompt
   - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApPipe.yaml
+    include:
+      - prompt
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
@@ -8,8 +8,10 @@ imports:
     # Include all metrics from standard pipeline. It's not practical to create
     # a metrics subset because it would require constant micromanagement.
     exclude:
-      - apPipe
+      - prompt
   - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml
+    include:
+      - prompt
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/_ingredients/ApVerify.yaml
+++ b/pipelines/_ingredients/ApVerify.yaml
@@ -3,6 +3,8 @@
 description: Fully instrumented AP pipeline.
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
+    include:
+      - prompt
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/MetricsRuntime.yaml
     exclude:
       - timing_calibrate

--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -4,6 +4,8 @@
 description: Fully instrumented AP pipeline with fakes
 imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
+    include:
+      - prompt
   # Most metrics should not be run with fakes, to avoid bias or contamination.
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ConversionsForFakes.yaml
 tasks:

--- a/pipelines/_ingredients/MetricsRuntime.yaml
+++ b/pipelines/_ingredients/MetricsRuntime.yaml
@@ -90,14 +90,6 @@ tasks:
       connections.metric: MapDiaSourceTime
       connections.labelName: transformDiaSrcCat
       target: transformDiaSrcCat.run
-  timing_diaCatalogLoader:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.package: ap_association
-      connections.metric: LoadDiaCatalogsTime
-      connections.labelName: loadDiaCatalogs
-      metadataDimensions: [instrument, group, detector]  # TimingMetricTask assumes visit
-      target: loadDiaCatalogs.run
   timing_diaPipe_associator:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
@@ -212,14 +204,6 @@ tasks:
       connections.metric: MapDiaSourceCpuTime
       connections.labelName: transformDiaSrcCat
       target: transformDiaSrcCat.run
-  cputiming_diaCatalogLoader:
-    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
-    config:
-      connections.package: ap_association
-      connections.metric: LoadDiaCatalogsCpuTime
-      connections.labelName: loadDiaCatalogs
-      metadataDimensions: [instrument, group, detector]  # CpuTimingMetricTask assumes visit
-      target: loadDiaCatalogs.run
   cputiming_diaPipe_associator:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:


### PR DESCRIPTION
This PR removes the preprocessing tasks from `ApVerify` pipelines. These datasets are now handled by the `ap_verify` data set itself, just like other inputs that are available when raws arrive.

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ ] Is the Sphinx documentation up-to-date?
