### PR TITLE
DM-46599: Stop using Butler regular expression searches

### DIFF
--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -31,7 +31,6 @@ __all__ = ["Gen3DatasetIngestConfig", "ingestDatasetGen3"]
 
 import fnmatch
 import os
-import re
 import shutil
 from glob import glob
 import logging
@@ -138,9 +137,12 @@ class Gen3DatasetIngestTask(pipeBase.Task):
         RuntimeError
             Raised if there are no files to ingest.
         """
-        # TODO: regex is workaround for DM-25945
-        rawCollectionFilter = re.compile(self.dataset.instrument.makeDefaultRawIngestRunName())
-        rawCollections = list(self.workspace.workButler.registry.queryCollections(rawCollectionFilter))
+        try:
+            collectionName = self.dataset.instrument.makeDefaultRawIngestRunName()
+            rawCollections = list(self.workspace.workButler.registry.queryCollections(collectionName))
+        except lsst.daf.butler.MissingCollectionError:
+            rawCollections = []
+
         rawData = list(self.workspace.workButler.registry.queryDatasets(
             'raw',
             collections=rawCollections,

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -277,7 +277,10 @@ def _getCollectionArguments(workspace, reuse):
     # skip-existing-in would work around that, but would lead to a worse bug in
     # the case that the user is alternating runs with and without --clean-run.
     # registry.refresh()
-    oldRuns = list(registry.queryCollections(re.compile(workspace.outputName + r"/\d+T\d+Z")))
+    collectionPattern = re.compile(workspace.outputName + r"/\d+T\d+Z")
+    oldRuns = list(registry.queryCollections(workspace.outputName + "/*"))
+    oldRuns = [run for run in oldRuns if collectionPattern.fullmatch(run)]
+
     if reuse and oldRuns:
         args.extend(["--extend-run", "--skip-existing"])
     return args

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -23,7 +23,6 @@
 
 import os
 import pickle
-import re
 import shutil
 import tempfile
 import unittest
@@ -133,9 +132,7 @@ class IngestionTestSuiteGen3(DataTestCase):
         # queryDatasets cannot (yet) search CALIBRATION collections, so we
         # instead search the RUN-type collections that calibrations are
         # ingested into first before being associated with a validity range.
-        calibrationRunPattern = re.compile(
-            re.escape(self.dataset.instrument.makeCollectionName("calib") + "/") + ".+"
-        )
+        calibrationRunPattern = self.dataset.instrument.makeCollectionName("calib") + "/*"
         calibrationRuns = list(
             self.butler.registry.queryCollections(
                 calibrationRunPattern,


### PR DESCRIPTION
Using regular expressions to search the Butler for collection names is deprecated in RFC-1040.

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ ] Is the Sphinx documentation up-to-date?
