### PR TITLE
DM-47299: Add the afterburner subset to all of the pipelines

### DIFF
--- a/pipelines/DECam/ApVerify.yaml
+++ b/pipelines/DECam/ApVerify.yaml
@@ -8,9 +8,11 @@ imports:
     # a metrics subset because it would require constant micromanagement.
     exclude:
       - prompt
+      - afterburner
   - location: $AP_PIPE_DIR/pipelines/DECam/ApPipe.yaml
     include:
       - prompt
+      - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/DECam/ApVerifyWithFakes.yaml
+++ b/pipelines/DECam/ApVerifyWithFakes.yaml
@@ -12,9 +12,11 @@ imports:
     # a metrics subset because it would require constant micromanagement.
     exclude:
       - prompt
+      - afterburner
   - location: $AP_PIPE_DIR/pipelines/DECam/ApPipeWithFakes.yaml
     include:
       - prompt
+      - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/HSC/ApVerify.yaml
+++ b/pipelines/HSC/ApVerify.yaml
@@ -8,9 +8,11 @@ imports:
     # a metrics subset because it would require constant micromanagement.
     exclude:
       - prompt
+      - afterburner
   - location: $AP_PIPE_DIR/pipelines/HSC/ApPipe.yaml
     include:
       - prompt
+      - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/HSC/ApVerifyWithFakes.yaml
+++ b/pipelines/HSC/ApVerifyWithFakes.yaml
@@ -9,9 +9,11 @@ imports:
     # a metrics subset because it would require constant micromanagement.
     exclude:
       - prompt
+      - afterburner
   - location: $AP_PIPE_DIR/pipelines/HSC/ApPipeWithFakes.yaml
     include:
       - prompt
+      - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/LSSTCam-imSim/ApVerify.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerify.yaml
@@ -8,9 +8,11 @@ imports:
     # a metrics subset because it would require constant micromanagement.
     exclude:
       - prompt
+      - afterburner
   - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApPipe.yaml
     include:
       - prompt
+      - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
@@ -9,9 +9,11 @@ imports:
     # a metrics subset because it would require constant micromanagement.
     exclude:
       - prompt
+      - afterburner
   - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/ApPipeWithFakes.yaml
     include:
       - prompt
+      - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
   diaPipe:

--- a/pipelines/_ingredients/ApVerify.yaml
+++ b/pipelines/_ingredients/ApVerify.yaml
@@ -5,6 +5,7 @@ imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipe.yaml
     include:
       - prompt
+      - afterburner
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/MetricsRuntime.yaml
     exclude:
       - timing_calibrate

--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -6,6 +6,7 @@ imports:
   - location: $AP_PIPE_DIR/pipelines/_ingredients/ApPipeWithFakes.yaml
     include:
       - prompt
+      - afterburner
   # Most metrics should not be run with fakes, to avoid bias or contamination.
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ConversionsForFakes.yaml
 tasks:


### PR DESCRIPTION
{Summary of changes. Prefix PR title with JIRA issue.}

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x] Is the Sphinx documentation up-to-date?
