### PR TITLE
DM-48122: Remove ProcessCcd.yaml from ap_pipe

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -6,10 +6,10 @@ The pipelines defined here come in three flavors: camera-specific (within named 
 Pipelines within the ingredients directory are meant to be imported by other pipelines, and are not intended to be used directly by end-users.
 
 The `pipetask build` command can be used to expand a pipeline YAML and resolve any imports for the purposes of visualizing it.
-For example, to visualize the `processCcd` subset from the [LSSTCam-imSim ApVerify pipeline](https://github.com/lsst/ap_verify/blob/main/pipelines/LSSTCam-imSim/ApVerify.yaml) pipeline, run:
+For example, to visualize the `apPipeSingleFrame` subset from the [LSSTCam-imSim ApVerify pipeline](https://github.com/lsst/ap_verify/blob/main/pipelines/LSSTCam-imSim/ApVerify.yaml) pipeline, run:
 
 ```bash
 pipetask build \
--p $AP_VERIFY_DIR/pipelines/LSSTCam-imSim/ApVerify.yaml#processCcd \
+-p $AP_VERIFY_DIR/pipelines/LSSTCam-imSim/ApVerify.yaml#apPipeSingleFrame \
 --show pipeline
 ```


### PR DESCRIPTION
This PR removes references to the `processCcd` pipeline subset, which was deprecated on lsst/ap_pipe#218.

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [X] Is the Sphinx documentation up-to-date?