### PR TITLE
DM-43419: Remove deprecated fields from DiaPipelineConfig

### DIFF
--- a/pipelines/DECam/ApVerify.yaml
+++ b/pipelines/DECam/ApVerify.yaml
@@ -22,6 +22,4 @@ tasks:
       alertPackager.doWriteAlerts: True
 contracts:
   # Contracts removed by excluding apPipe
-  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
-    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
-  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)
+  - diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url

--- a/pipelines/HSC/ApVerify.yaml
+++ b/pipelines/HSC/ApVerify.yaml
@@ -22,6 +22,4 @@ tasks:
       alertPackager.doWriteAlerts: True
 contracts:
   # Contracts removed by excluding apPipe
-  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
-    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
-  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)
+  - diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url

--- a/pipelines/LSSTCam-imSim/ApVerify.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerify.yaml
@@ -22,6 +22,4 @@ tasks:
       alertPackager.doWriteAlerts: True
 contracts:
   # Contracts removed by excluding apPipe
-  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
-    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
-  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)
+  - diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url

--- a/pipelines/_ingredients/ApVerify.yaml
+++ b/pipelines/_ingredients/ApVerify.yaml
@@ -23,6 +23,4 @@ tasks:
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
 contracts:
-  - contract: diaPipe.doConfigureApdb or not totalUnassociatedDiaObjects.doReadMarker
-    msg: "totalUnassociatedDiaObjects.doReadMarker requires diaPipe.doConfigureApdb"
-  - (totalUnassociatedDiaObjects.doReadMarker) or (diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url)
+  - diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url

--- a/pipelines/_ingredients/MetricsMisc.yaml
+++ b/pipelines/_ingredients/MetricsMisc.yaml
@@ -26,5 +26,4 @@ tasks:
   totalUnassociatedDiaObjects:
     class: lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask
     config:
-        doReadMarker: False  # Impossible if diaPipe uses new-style config
         apdb_config_url: parameters.apdb_config

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -170,8 +170,7 @@ def _getExecOrder():
 
 
 def _getPipelineFile(workspace, parsed):
-    """Return the config options for running make_apdb.py on this workspace,
-    as command-line arguments.
+    """Return the pipeline to be run.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR removes the compatibility config patches added in #224. The config flags themselves were removed by lsst/verify#126 and lsst/ap_association#264.

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ ] Is the Sphinx documentation up-to-date?
