### PR TITLE
DM-46249: Add SasquatchDatastore to enable uploading analysis_tools metrics

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -65,7 +65,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    Multiple copies of this argument are allowed.
 
    If this argument is omitted, then all data IDs in the dataset will be processed.
-   
+
 .. option:: --dataset <dataset_package>
 
    **Input dataset package.**
@@ -87,6 +87,15 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
    If this argument is omitted, ``ap_verify`` creates an SQLite database inside the directory indicated by :option:`--output`.
 
+.. option:: --namespace <sasquatch_namespace>
+
+   The sasquastch namespace to use for the ap_verify metrics upload.
+   If this is provided, then a valid REST proxy URL must be provided with :option:`--restProxyUrl`.
+
+.. option:: --restProxyUrl <sasquastch_proxy_url>
+
+   A URI string identifying the Sasquastch url to use for the ap_verify metrics upload. If this is provided, then a valid :option:`--namespace` must be provided.
+
 .. option:: -h, --help
 
    **Print help.**
@@ -98,7 +107,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
    **Number of processes to use.**
 
    When ``processes`` is larger than 1 the pipeline may use the Python `multiprocessing` module to parallelize processing of multiple datasets across multiple processors.
-   
+
 .. option:: --output <workspace_dir>
 
    **Output and intermediate product path.**

--- a/python/lsst/ap/verify/ap_verify.py
+++ b/python/lsst/ap/verify/ap_verify.py
@@ -36,7 +36,7 @@ import logging
 import lsst.log
 
 from .dataset import Dataset
-from .ingestion import ingestDatasetGen3
+from .ingestion import ingestDatasetGen3, IngestionParser
 from .pipeline_driver import ApPipeParser, runApPipeGen3
 from .workspace import WorkspaceGen3
 
@@ -92,7 +92,7 @@ class _ApVerifyParser(argparse.ArgumentParser):
             self,
             description='Executes the LSST DM AP pipeline and analyzes its performance using metrics.',
             epilog='',
-            parents=[_InputOutputParser(), _ProcessingParser(), ApPipeParser(), ],
+            parents=[IngestionParser(), _InputOutputParser(), _ProcessingParser(), ApPipeParser(), ],
             add_help=True)
 
 
@@ -109,7 +109,7 @@ class _IngestOnlyParser(argparse.ArgumentParser):
             'passing the same --output argument, or by other programs that accept '
             'Butler repositories as input.',
             epilog='',
-            parents=[_InputOutputParser(), _ProcessingParser()],
+            parents=[IngestionParser(), _InputOutputParser(), _ProcessingParser()],
             add_help=True)
 
 
@@ -150,7 +150,7 @@ def runApVerify(cmdLine=None):
     log.debug('Command-line arguments: %s', args)
 
     workspace = WorkspaceGen3(args.output)
-    ingestDatasetGen3(args.dataset, workspace, processes=args.processes)
+    ingestDatasetGen3(args.dataset, workspace, args.namespace, args.restProxyUrl, processes=args.processes)
     log.info('Running pipeline...')
     # Gen 3 pipeline includes both AP and metrics
     return runApPipeGen3(workspace, args, processes=args.processes)


### PR DESCRIPTION
Update ci run script to take namespace and url for sasquatch upload."

Add optional ChainedDatastore to host SasquatchDatastore

Add new parameters to accomodate for Sasquatch metric upload

{Summary of changes. Prefix PR title with JIRA issue.}

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x] Is the Sphinx documentation up-to-date?
