### PR TITLE
DM-46249: Hotfix for Sasquatch parameters and unit tests

### DIFF
--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -155,7 +155,7 @@ class Dataset:
         """
         return f"Dataset({self._id!r})"
 
-    def makeCompatibleRepoGen3(self, repoDir, sasquatchNamespace, sasquatchRestProxyUrl):
+    def makeCompatibleRepoGen3(self, repoDir, sasquatchNamespace=None, sasquatchRestProxyUrl=None):
         """Set up a directory as a Gen 3 repository compatible with this ap_verify dataset.
 
         If the repository already exists, this call has no effect.
@@ -164,6 +164,12 @@ class Dataset:
         ----------
         repoDir : `str`
             The directory where the output repository will be created.
+        sasquatchNamespace : `str`, optional
+            The namespace to which to upload analysis_tools metrics. If
+            omitted, no metrics are uploaded.
+        sasquatchRestProxyUrl : `str`, optional
+            The server to which to upload analysis_tools metrics. Must be
+            provided if ``sasquatchNamespace`` is.
         """
         # No way to tell makeRepo "create only what's missing"
         try:

--- a/python/lsst/ap/verify/ingestion.py
+++ b/python/lsst/ap/verify/ingestion.py
@@ -112,13 +112,19 @@ class Gen3DatasetIngestTask(pipeBase.Task):
     workspace : `lsst.ap.verify.workspace.WorkspaceGen3`
         The abstract location for all ``ap_verify`` outputs, including
         a Gen 3 repository.
+    namespace : `str`, optional
+        The Sasquatch namespace to which to upload analysis_tools metrics. If
+        omitted, no metrics are uploaded.
+    url : `str`, optional
+        The Sasquatch server to which to upload analysis_tools metrics. Must be
+        provided if ``namespace`` is.
     """
 
     ConfigClass = Gen3DatasetIngestConfig
     # Suffix is de-facto convention for distinguishing Gen 2 and Gen 3 config overrides
     _DefaultName = "datasetIngest-gen3"
 
-    def __init__(self, dataset, workspace, namespace, url, *args, **kwargs):
+    def __init__(self, dataset, workspace, namespace=None, url=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.workspace = workspace
         self.dataset = dataset
@@ -270,7 +276,7 @@ class Gen3DatasetIngestTask(pipeBase.Task):
             self.log.info("Configs are now stored in %s.", self.workspace.pipelineDir)
 
 
-def ingestDatasetGen3(dataset, workspace, sasquatchNamespace, sasquatchUrl, processes=1):
+def ingestDatasetGen3(dataset, workspace, sasquatchNamespace=None, sasquatchUrl=None, processes=1):
     """Ingest the contents of an ap_verify dataset into a Gen 3 Butler repository.
 
     The original data directory is not modified.
@@ -282,11 +288,11 @@ def ingestDatasetGen3(dataset, workspace, sasquatchNamespace, sasquatchUrl, proc
     workspace : `lsst.ap.verify.workspace.WorkspaceGen3`
         The abstract location where the epository is be created, if it does
         not already exist.
-    sasquatchNamespace : `str`
+    sasquatchNamespace : `str`, optional
         The name of the namespace to post the ap_verify metrics to.
-    sasquatchUrl : `str`
+    sasquatchUrl : `str`, optional
         The URL of the server to post the ap_verify metrics to.
-    processes : `int`
+    processes : `int`, optional
         The number processes to use to ingest.
     """
     log = _LOG.getChild("ingestDataset")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -87,7 +87,7 @@ class DatasetTestSuite(DataTestCase):
         outputDir = os.path.join(testDir, 'goodOut')
 
         try:
-            self._testbed.makeCompatibleRepoGen3(outputDir, "sasquatch", None)
+            self._testbed.makeCompatibleRepoGen3(outputDir)
             self._checkOutputGen3(outputDir)
         finally:
             if os.path.exists(testDir):
@@ -101,9 +101,9 @@ class DatasetTestSuite(DataTestCase):
         outputDir = os.path.join(testDir, 'badOut')
 
         try:
-            self._testbed.makeCompatibleRepoGen3(outputDir, "sasquatch", None)
+            self._testbed.makeCompatibleRepoGen3(outputDir)
             self._checkOutputGen3(outputDir)
-            self._testbed.makeCompatibleRepoGen3(outputDir, "sasquatch", None)
+            self._testbed.makeCompatibleRepoGen3(outputDir)
             self._checkOutputGen3(outputDir)
         finally:
             if os.path.exists(testDir):

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -61,7 +61,7 @@ class PipelineDriverTestSuiteGen3(DataTestCase):
         self.addCleanup(shutil.rmtree, self._testDir, ignore_errors=True)
 
         self.workspace = WorkspaceGen3(self._testDir)
-        self.dataset.makeCompatibleRepoGen3(self.workspace.repo, "sasquatch", None)
+        self.dataset.makeCompatibleRepoGen3(self.workspace.repo)
         raws = [os.path.join(self.dataset.rawLocation, "lsst_a_204595_R11_S01_i.fits")]
         rawIngest = RawIngestTask(butler=self.workspace.workButler, config=RawIngestTask.ConfigClass())
         rawIngest.run(raws, run=None)

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -77,10 +77,7 @@ class IngestionTestSuiteGen3(DataTestCase):
         self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
         self.workspace = WorkspaceGen3(self.root)
         self.task = ingestion.Gen3DatasetIngestTask(config=self.config,
-                                                    dataset=self.dataset,
-                                                    workspace=self.workspace,
-                                                    namespace="sasquatch",
-                                                    url=None)
+                                                    dataset=self.dataset, workspace=self.workspace)
 
         self.butler = self.workspace.workButler
 


### PR DESCRIPTION
This PR reverts the test changes on #245 (as we should be able to run `ap_verify` without access to Sasquatch) and instead makes the relevant parameters optional. It also adds documentation missing from #244.

****

- [X] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [X] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ ] Is the Sphinx documentation up-to-date?
