### PR TITLE
DM-46249-hotfix3 : Upload analysis_tools metrics from ap_verify so they can be retrieved in Chronograf

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -131,3 +131,9 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
       At present, ap_verify assumes that the provided pipeline includes the ``diaPipe`` task from the AP pipeline, and configures it on the fly.
       It will likely crash if this task is missing.
+
+.. option:: --extra <key=value>
+
+   **Optional extra key=value arguments.**
+
+   These arguments are passed directly to the ``ap_verify`` pipeline, they are used in case a SasquastchDatastore is created, and are in the form ``key=value``. In the context of CI, a Jenkins job would tag the test run with these extra parameters.

--- a/python/lsst/ap/verify/dataset.py
+++ b/python/lsst/ap/verify/dataset.py
@@ -155,7 +155,8 @@ class Dataset:
         """
         return f"Dataset({self._id!r})"
 
-    def makeCompatibleRepoGen3(self, repoDir, sasquatchNamespace=None, sasquatchRestProxyUrl=None):
+    def makeCompatibleRepoGen3(self, repoDir, sasquatchNamespace=None, sasquatchRestProxyUrl=None,
+                               extra=None):
         """Set up a directory as a Gen 3 repository compatible with this ap_verify dataset.
 
         If the repository already exists, this call has no effect.
@@ -169,6 +170,9 @@ class Dataset:
             omitted, no metrics are uploaded.
         sasquatchRestProxyUrl : `str`, optional
             The server to which to upload analysis_tools metrics. Must be
+            provided if ``sasquatchNamespace`` is.
+        extra : `dict`, optional
+            Extra parameters needed to post ap_verify metrics. Should be
             provided if ``sasquatchNamespace`` is.
         """
         # No way to tell makeRepo "create only what's missing"
@@ -188,6 +192,7 @@ class Dataset:
                     {"cls": "lsst.analysis.tools.interfaces.datastore.SasquatchDatastore",
                      "restProxyUrl": sasquatchRestProxyUrl,
                      "namespace": sasquatchNamespace,
+                     "extra_fields": extra if extra is not None else {},
                      },
                 ]
                 seedConfig["datastore", "datastores"] = datastores


### PR DESCRIPTION
DM-46249: Upload analysis_tools metrics from ap_verify so they can be retrieved in Chronograf
Fix to support optional arguments to ap_verify script, allowing additional keyword,value inputs for dispatching to SasquatchDatastore and Chronograph uploads in CI.

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x] Is the Sphinx documentation up-to-date?
