### PR TITLE
DM-49875: rename task labels and dataset names for RFC-1088

### DIFF
--- a/doc/lsst.ap.verify/command-line-reference.rst
+++ b/doc/lsst.ap.verify/command-line-reference.rst
@@ -129,7 +129,7 @@ Required arguments are :option:`--dataset` and :option:`--output`.
 
    .. note::
 
-      At present, ap_verify assumes that the provided pipeline includes the ``diaPipe`` task from the AP pipeline, and configures it on the fly.
+      At present, ap_verify assumes that the provided pipeline includes the ``apdb_config`` parameter, which should be a path to the file created by ``apdb-cli create-cassandra`` or ``apdb-cli create-sql`` when initializing the APDB.
       It will likely crash if this task is missing.
 
 .. option:: --extra <key=value>

--- a/doc/lsst.ap.verify/limitations.rst
+++ b/doc/lsst.ap.verify/limitations.rst
@@ -11,4 +11,4 @@ mpSkyEphemerisQueryTask
 
 The AP pipelines now run :py:class:`lsst.ap.association.MPSkyEphemerisQueryTask`, which includes a request to mpSky.
 mpSky is not expected to host ephemerides for all test datasets, (or be reachable from Jenkins) so it will often (or always) fail.
-When requests fail, mpSkyEphemerisQuery will return nothing, and diaPipe will skip ssoAssociation.
+When requests fail, mpSkyEphemerisQuery will return nothing, and associateApdb will skip ssoAssociation.

--- a/pipelines/DECam/ApVerify.yaml
+++ b/pipelines/DECam/ApVerify.yaml
@@ -15,11 +15,11 @@ imports:
       - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
-  diaPipe:
+  associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
 contracts:
   # Contracts removed by excluding apPipe
-  - diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url
+  - associateApdb.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url

--- a/pipelines/DECam/ApVerifyWithFakes.yaml
+++ b/pipelines/DECam/ApVerifyWithFakes.yaml
@@ -19,7 +19,7 @@ imports:
       - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
-  diaPipe:
+  associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True

--- a/pipelines/HSC/ApVerify.yaml
+++ b/pipelines/HSC/ApVerify.yaml
@@ -15,11 +15,11 @@ imports:
       - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
-  diaPipe:
+  associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
 contracts:
   # Contracts removed by excluding apPipe
-  - diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url
+  - associateApdb.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url

--- a/pipelines/HSC/ApVerifyWithFakes.yaml
+++ b/pipelines/HSC/ApVerifyWithFakes.yaml
@@ -16,7 +16,7 @@ imports:
       - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
-  diaPipe:
+  associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True

--- a/pipelines/LSSTCam-imSim/ApVerify.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerify.yaml
@@ -15,11 +15,11 @@ imports:
       - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
-  diaPipe:
+  associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
 contracts:
   # Contracts removed by excluding apPipe
-  - diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url
+  - associateApdb.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url

--- a/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
+++ b/pipelines/LSSTCam-imSim/ApVerifyWithFakes.yaml
@@ -16,7 +16,7 @@ imports:
       - afterburner
 tasks:
   # ApVerify override removed by excluding apPipe.
-  diaPipe:
+  associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doPackageAlerts: True

--- a/pipelines/_ingredients/ApVerify.yaml
+++ b/pipelines/_ingredients/ApVerify.yaml
@@ -7,11 +7,6 @@ imports:
       - prompt
       - afterburner
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/MetricsRuntime.yaml
-    exclude:
-      - timing_calibrate
-      - timing_characterizeImage
-      - cputiming_calibrate
-      - cputiming_characterizeImage
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/MetricsMisc.yaml
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/Conversions.yaml
 tasks:

--- a/pipelines/_ingredients/ApVerify.yaml
+++ b/pipelines/_ingredients/ApVerify.yaml
@@ -15,7 +15,7 @@ imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/MetricsMisc.yaml
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/Conversions.yaml
 tasks:
-  diaPipe:
+  associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       # TODO: needed for "providing bulk sample alerts to brokers"; remove once
@@ -23,4 +23,4 @@ tasks:
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
 contracts:
-  - diaPipe.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url
+  - associateApdb.apdb_config_url == totalUnassociatedDiaObjects.apdb_config_url

--- a/pipelines/_ingredients/ApVerifyWithFakes.yaml
+++ b/pipelines/_ingredients/ApVerifyWithFakes.yaml
@@ -10,7 +10,7 @@ imports:
   # Most metrics should not be run with fakes, to avoid bias or contamination.
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ConversionsForFakes.yaml
 tasks:
-  diaPipe:
+  associateApdb:
     class: lsst.ap.association.DiaPipelineTask
     config:
       # TODO: needed for "providing bulk sample alerts to brokers"; remove once

--- a/pipelines/_ingredients/Conversions.yaml
+++ b/pipelines/_ingredients/Conversions.yaml
@@ -5,37 +5,37 @@
 description: Type conversion tasks customized for AP pipeline, with CalibrateImage.
 
 tasks:
-  # Merging of initial_stars_detector [detector-level] to initial_stars [visit-level]
+  # Merging of single_visit_star_unstandardized [detector-level] to initial_stars [visit-level]
   consolidateSourceTable:
     class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
     config:
       # This is output directly by CalibrateImageTask.
-      connections.inputCatalogs: initial_stars_detector
+      connections.inputCatalogs: single_visit_star_unstandardized
       connections.outputCatalog: initial_stars
 
-  # Merging of *Diff_diaSrcTable [detector-level Parquet] to diaSourceTable [visit-level]
+  # Merging of *Diff_diaSrcTable [detector-level Parquet] to dia_source_visit [visit-level]
   consolidateDiaSourceTable:
     class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
     config:
       # Task doesn't support coaddName, so coopt catalogType instead.
       connections.catalogType: parameters.coaddName
-      connections.inputCatalogs: "{catalogType}Diff_diaSrcTable"
-      connections.outputCatalog: diaSourceTable
+      connections.inputCatalogs: dia_source_detector
+      connections.outputCatalog: dia_source_visit
 
   consolidateVisitSummary:
     class: lsst.pipe.tasks.postprocess.ConsolidateVisitSummaryTask
     config:
-      connections.calexp: initial_pvi
-      connections.visitSummary: visitSummary
-      connections.visitSummarySchema: visitSummary_schema
+      connections.calexp: preliminary_visit_image
+      connections.visitSummary: preliminary_visit_summary
+      connections.visitSummarySchema: preliminary_visit_summary_schema
   makeVisitTable:
     class: lsst.pipe.tasks.postprocess.MakeVisitTableTask
     config:
-      connections.visitSummaries: "{calexpType}visitSummary"
-      connections.outputCatalog: "{calexpType}visitTable"
-  # Conversion of visitSummary [visit-level afw.table] to ccdVisitTable [instrument-level Parquet]
+      connections.visitSummaries: "{calexpType}preliminary_visit_summary"
+      connections.outputCatalog: "{calexpType}visit_table"
+  # Conversion of preliminary_visit_summary [visit-level afw.table] to visit_detector_table [instrument-level Parquet]
   makeCcdVisitTable:
     class: lsst.pipe.tasks.postprocess.MakeCcdVisitTableTask
     config:
-      connections.visitSummaryRefs: "{calexpType}visitSummary"
-      connections.outputCatalog: "{calexpType}ccdVisitTable"
+      connections.visitSummaryRefs: "{calexpType}preliminary_visit_summary"
+      connections.outputCatalog: "{calexpType}visit_detector_table"

--- a/pipelines/_ingredients/Conversions.yaml
+++ b/pipelines/_ingredients/Conversions.yaml
@@ -26,12 +26,16 @@ tasks:
     class: lsst.pipe.tasks.postprocess.ConsolidateVisitSummaryTask
     config:
       connections.calexp: initial_pvi
+      connections.visitSummary: visitSummary
+      connections.visitSummarySchema: visitSummary_schema
   makeVisitTable:
     class: lsst.pipe.tasks.postprocess.MakeVisitTableTask
     config:
       connections.visitSummaries: "{calexpType}visitSummary"
+      connections.outputCatalog: "{calexpType}visitTable"
   # Conversion of visitSummary [visit-level afw.table] to ccdVisitTable [instrument-level Parquet]
   makeCcdVisitTable:
     class: lsst.pipe.tasks.postprocess.MakeCcdVisitTableTask
     config:
       connections.visitSummaryRefs: "{calexpType}visitSummary"
+      connections.outputCatalog: "{calexpType}ccdVisitTable"

--- a/pipelines/_ingredients/ConversionsForFakes.yaml
+++ b/pipelines/_ingredients/ConversionsForFakes.yaml
@@ -8,7 +8,7 @@ description: Type conversion tasks customized for AP pipeline
 imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/Conversions.yaml
     exclude:
-      # Fakes pipeline doesn't produce non-fakes DiaSourceTable.
+      # Fakes pipeline doesn't produce non-fakes dia_source_visit.
       - consolidateDiaSourceTable
 tasks:
   # TODO: TransformSourceTableTask can't be run until we create a functor
@@ -18,38 +18,35 @@ tasks:
     class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
     config:
       # This is output directly by CalibrateImageTask.
-      connections.inputCatalogs: initial_stars_detector
-      connections.outputCatalog: initial_stars
+      connections.inputCatalogs: single_visit_star_unstandardized
+      connections.outputCatalog: consolidated_single_visit_star_unstandardized
   # Merging of fakes_*Diff_diaSrcTable [detector-level Parquet] to fakes_diaSourceTable [visit-level]
   consolidateDiaSourceTable:
     class: lsst.pipe.tasks.postprocess.ConsolidateSourceTableTask
     config:
-      # Task doesn't support coaddName, so coopt catalogType instead.
-      connections.catalogType: parameters.coaddName
-      # TODO: hard-code the "fakes_" label because I can't insert two templates,
-      # and fakesType is more stable than coaddName.
-      connections.inputCatalogs: "fakes_{catalogType}Diff_diaSrcTable"
-      connections.outputCatalog: fakes_diaSourceTable
-  # Creation of fakes_visitSummary
+      connections.catalogType: parameters.fakesType
+      connections.inputCatalogs: "{catalogType}dia_source_detector"
+      connections.outputCatalog: "{catalogType}dia_source_visit"
+  # Creation of fakes_preliminary_visit_summary
   consolidateVisitSummary:
     class: lsst.pipe.tasks.postprocess.ConsolidateVisitSummaryTask
     config:
       connections.calexpType: parameters.fakesType
-      connections.calexp: "{calexpType}initial_pvi"
-      connections.visitSummary: "{calexpType}visitSummary"
-      connections.visitSummarySchema: "{calexpType}visitSummary_schema"
-  # Conversion of fakes_visitSummary [visit-level afw.table] to fakes_visitTable [instrument-level Parquet]
+      connections.calexp: "{calexpType}preliminary_visit_image"
+      connections.visitSummary: "{calexpType}preliminary_visit_summary"
+      connections.visitSummarySchema: "{calexpType}preliminary_visit_summary_schema"
+  # Conversion of fakes_preliminary_visit_summary [visit-level afw.table] to fakes_visitTable [instrument-level Parquet]
   makeVisitTable:
     class: lsst.pipe.tasks.postprocess.MakeVisitTableTask
     config:
       connections.calexpType: parameters.fakesType
-      connections.visitSummaries: "{calexpType}visitSummary"
-  # Conversion of fakes_visitSummary [visit-level afw.table] to fakes_ccdVisitTable [instrument-level Parquet]
-      connections.outputCatalog: "{calexpType}visitTable"
+      connections.visitSummaries: "{calexpType}preliminary_visit_summary"
+      connections.outputCatalog: "{calexpType}visit_table"
+  # Conversion of fakes_preliminary_visit_summary [visit-level afw.table] to fakes_visit_detector_table [instrument-level Parquet]
   makeCcdVisitTable:
     class: lsst.pipe.tasks.postprocess.MakeCcdVisitTableTask
     config:
       connections.calexpType: parameters.fakesType
-      connections.visitSummaryRefs: "{calexpType}visitSummary"
-      connections.outputCatalog: "{calexpType}ccdVisitTable"
+      connections.visitSummaryRefs: "{calexpType}preliminary_visit_summary"
+      connections.outputCatalog: "{calexpType}visit_detector_table"
 

--- a/pipelines/_ingredients/ConversionsForFakes.yaml
+++ b/pipelines/_ingredients/ConversionsForFakes.yaml
@@ -45,9 +45,11 @@ tasks:
       connections.calexpType: parameters.fakesType
       connections.visitSummaries: "{calexpType}visitSummary"
   # Conversion of fakes_visitSummary [visit-level afw.table] to fakes_ccdVisitTable [instrument-level Parquet]
+      connections.outputCatalog: "{calexpType}visitTable"
   makeCcdVisitTable:
     class: lsst.pipe.tasks.postprocess.MakeCcdVisitTableTask
     config:
       connections.calexpType: parameters.fakesType
       connections.visitSummaryRefs: "{calexpType}visitSummary"
+      connections.outputCatalog: "{calexpType}ccdVisitTable"
 

--- a/pipelines/_ingredients/MetricsMisc.yaml
+++ b/pipelines/_ingredients/MetricsMisc.yaml
@@ -6,23 +6,23 @@ tasks:
   numNewDiaObjects:
     class: lsst.ap.association.metrics.NumberNewDiaObjectsMetricTask
     config:
-      connections.labelName: diaPipe  # partial name of metadata dataset
+      connections.labelName: associateApdb  # partial name of metadata dataset
   numUnassociatedDiaObjects:
     class: lsst.ap.association.metrics.NumberUnassociatedDiaObjectsMetricTask
     config:
-      connections.labelName: diaPipe
+      connections.labelName: associateApdb
   fracUpdatedDiaObjects:
     class: lsst.ap.association.metrics.FractionUpdatedDiaObjectsMetricTask
     config:
-      connections.labelName: diaPipe
+      connections.labelName: associateApdb
   numTotalSolarSystemObjects:
     class: lsst.ap.association.metrics.NumberSolarSystemObjectsMetricTask
     config:
-      connections.labelName: diaPipe
+      connections.labelName: associateApdb
   numAssociatedSsObjects:
     class: lsst.ap.association.metrics.NumberAssociatedSolarSystemObjectsMetricTask
     config:
-      connections.labelName: diaPipe
+      connections.labelName: associateApdb
   totalUnassociatedDiaObjects:
     class: lsst.ap.association.metrics.TotalUnassociatedDiaObjectsMetricTask
     config:

--- a/pipelines/_ingredients/MetricsRuntime.yaml
+++ b/pipelines/_ingredients/MetricsRuntime.yaml
@@ -10,22 +10,6 @@ tasks:
       connections.labelName: isr   # partial name of metadata dataset
       metadataDimensions: [instrument, exposure, detector]  # TimingMetricTask assumes visit
       target: isr.run              # method name in metadata. Usually matches label for top-level tasks
-  # TODO XXXX: These two can be removed once the pipeline that uses characterize/calibrate is gone.
-  timing_characterizeImage:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.package: pipe_tasks
-      connections.metric: CharacterizeImageTime
-      connections.labelName: characterizeImage
-      target: characterizeImage.run
-  timing_calibrate:
-    class: lsst.verify.tasks.commonMetrics.TimingMetricTask
-    config:
-      connections.package: pipe_tasks
-      connections.metric: CalibrateTime
-      connections.labelName: calibrate
-      target: calibrate.run
-  ###
   timing_calibrateImage:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
@@ -126,20 +110,6 @@ tasks:
       connections.labelName: isr
       metadataDimensions: [instrument, exposure, detector]  # TimingMetricTask assumes visit
       target: isr.run
-  cputiming_characterizeImage:
-    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
-    config:
-      connections.package: pipe_tasks
-      connections.metric: CharacterizeImageCpuTime
-      connections.labelName: characterizeImage
-      target: characterizeImage.run
-  cputiming_calibrate:
-    class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
-    config:
-      connections.package: pipe_tasks
-      connections.metric: CalibrateCpuTime
-      connections.labelName: calibrate
-      target: calibrate.run
   cputiming_calibrateImage:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:

--- a/pipelines/_ingredients/MetricsRuntime.yaml
+++ b/pipelines/_ingredients/MetricsRuntime.yaml
@@ -33,14 +33,14 @@ tasks:
       connections.metric: CalibrateImageTime
       connections.labelName: calibrateImage
       target: calibrateImage.run
-  timing_retrieveTemplate:
+  timing_rewarpTemplate:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
       connections.package: ip_diffim
       connections.metric: GetTemplateTime
-      connections.labelName: retrieveTemplate
+      connections.labelName: rewarpTemplate
       metadataDimensions: [instrument, visit, detector, skymap]
-      target: retrieveTemplate.run
+      target: rewarpTemplate.run
   timing_subtractImages:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
@@ -53,71 +53,71 @@ tasks:
     config:
       connections.package: ip_diffim
       connections.metric: DetectAndMeasureTime
-      connections.labelName: detectAndMeasure
-      target: detectAndMeasure.run
+      connections.labelName: detectAndMeasureDiaSource
+      target: detectAndMeasureDiaSource.run
   timing_detectAndMeasure_detection:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
       connections.package: meas_algorithms
       connections.metric: SourceDetectionTime
-      connections.labelName: detectAndMeasure
-      target: detectAndMeasure:detection.run
+      connections.labelName: detectAndMeasureDiaSource
+      target: detectAndMeasureDiaSource:detection.run
   timing_detectAndMeasure_measurement:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
       connections.package: ip_diffim
       connections.metric: DipoleFitTime
-      connections.labelName: detectAndMeasure
-      target: detectAndMeasure:measurement.run
-  timing_rbClassify:
+      connections.labelName: detectAndMeasureDiaSource
+      target: detectAndMeasureDiaSource:measurement.run
+  timing_computeReliability:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
       connections.package: meas_transinet
       connections.metric: RBTransiNetTime
-      connections.labelName: rbClassify
-      target: rbClassify.run
-  timing_diaPipe:
+      connections.labelName: computeReliability
+      target: computeReliability.run
+  timing_associateApdb:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: DiaPipelineTime
-      connections.labelName: diaPipe
-      target: diaPipe.run
-  timing_transformDiaSrcCat:
+      connections.labelName: associateApdb
+      target: associateApdb.run
+  timing_standardizeDiaSource:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: MapDiaSourceTime
-      connections.labelName: transformDiaSrcCat
-      target: transformDiaSrcCat.run
-  timing_diaPipe_associator:
+      connections.labelName: standardizeDiaSource
+      target: standardizeDiaSource.run
+  timing_associateApdb_associator:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: AssociationTime
-      connections.labelName: diaPipe
-      target: diaPipe:associator.run
-  timing_diaPipe_diaForcedSource:
+      connections.labelName: associateApdb
+      target: associateApdb:associator.run
+  timing_associateApdb_diaForcedSource:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: DiaForcedSourceTime
-      connections.labelName: diaPipe
-      target: diaPipe:diaForcedSource.run
-  timing_diaPipe_alertPackager:
+      connections.labelName: associateApdb
+      target: associateApdb:diaForcedSource.run
+  timing_associateApdb_alertPackager:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: PackageAlertsTime
-      connections.labelName: diaPipe
-      target: diaPipe:alertPackager.run
-  timing_filterDiaSrcCat:
+      connections.labelName: associateApdb
+      target: associateApdb:alertPackager.run
+  timing_filterDiaSource:
     class: lsst.verify.tasks.commonMetrics.TimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: FilterDiaSourceCatalogTime
-      connections.labelName: filterDiaSrcCat
-      target: filterDiaSrcCat.run
+      connections.labelName: filterDiaSource
+      target: filterDiaSource.run
   cputiming_isr:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
@@ -147,14 +147,14 @@ tasks:
       connections.metric: CalibrateImageCpuTime
       connections.labelName: calibrateImage
       target: calibrateImage.run
-  cputiming_retrieveTemplate:
+  cputiming_rewarpTemplate:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: ip_diffim
       connections.metric: GetTemplateCpuTime
-      connections.labelName: retrieveTemplate
+      connections.labelName: rewarpTemplate
       metadataDimensions: [instrument, visit, detector, skymap]
-      target: retrieveTemplate.run
+      target: rewarpTemplate.run
   cputiming_subtractImages:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
@@ -167,98 +167,98 @@ tasks:
     config:
       connections.package: ip_diffim
       connections.metric: DetectAndMeasureCpuTime
-      connections.labelName: detectAndMeasure
-      target: detectAndMeasure.run
+      connections.labelName: detectAndMeasureDiaSource
+      target: detectAndMeasureDiaSource.run
   cputiming_detectAndMeasure_detection:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: meas_algorithms
       connections.metric: SourceDetectionCpuTime
-      connections.labelName: detectAndMeasure
-      target: detectAndMeasure:detection.run
+      connections.labelName: detectAndMeasureDiaSource
+      target: detectAndMeasureDiaSource:detection.run
   cputiming_detectAndMeasure_measurement:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: ip_diffim
       connections.metric: DipoleFitCpuTime
-      connections.labelName: detectAndMeasure
-      target: detectAndMeasure:measurement.run
-  cputiming_diaPipe:
+      connections.labelName: detectAndMeasureDiaSource
+      target: detectAndMeasureDiaSource:measurement.run
+  cputiming_associateApdb:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: DiaPipelineCpuTime
-      connections.labelName: diaPipe
-      target: diaPipe.run
-  cputiming_rbClassify:
+      connections.labelName: associateApdb
+      target: associateApdb.run
+  cputiming_computeReliability:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: meas_transinet
       connections.metric: RBTransiNetCpuTime
-      connections.labelName: rbClassify
-      target: rbClassify.run
-  cputiming_transformDiaSrcCat:
+      connections.labelName: computeReliability
+      target: computeReliability.run
+  cputiming_standardizeDiaSource:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: MapDiaSourceCpuTime
-      connections.labelName: transformDiaSrcCat
-      target: transformDiaSrcCat.run
-  cputiming_diaPipe_associator:
+      connections.labelName: standardizeDiaSource
+      target: standardizeDiaSource.run
+  cputiming_associateApdb_associator:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: AssociationCpuTime
-      connections.labelName: diaPipe
-      target: diaPipe:associator.run
-  cputiming_diaPipe_diaForcedSource:
+      connections.labelName: associateApdb
+      target: associateApdb:associator.run
+  cputiming_associateApdb_diaForcedSource:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: DiaForcedSourceCpuTime
-      connections.labelName: diaPipe
-      target: diaPipe:diaForcedSource.run
-  cputiming_diaPipe_alertPackager:
+      connections.labelName: associateApdb
+      target: associateApdb:diaForcedSource.run
+  cputiming_associateApdb_alertPackager:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: PackageAlertsCpuTime
-      connections.labelName: diaPipe
-      target: diaPipe:alertPackager.run
-  cputiming_filterDiaSrcCat:
+      connections.labelName: associateApdb
+      target: associateApdb:alertPackager.run
+  cputiming_filterDiaSource:
     class: lsst.verify.tasks.commonMetrics.CpuTimingMetricTask
     config:
       connections.package: ap_association
       connections.metric: FilterDiaSourceCatalogCpuTime
-      connections.labelName: filterDiaSrcCat
-      target: filterDiaSrcCat.run
+      connections.labelName: filterDiaSource
+      target: filterDiaSource.run
   memory_apPipe:
     class: lsst.verify.tasks.commonMetrics.MemoryMetricTask
     config:
       connections.package: ap_pipe
       connections.metric: ApPipeMemory
-      connections.labelName: diaPipe
-      target: diaPipe.run  # Memory use is peak over process, so measure last task
+      connections.labelName: associateApdb
+      target: associateApdb.run  # Memory use is peak over process, so measure last task
   memory_diaForcedSource:
     class: lsst.verify.tasks.commonMetrics.MemoryMetricTask
     config:
       connections.package: ap_association
       connections.metric: DiaForcedSourceMemory
-      connections.labelName: diaPipe
-      target: diaPipe:diaForcedSource.run
+      connections.labelName: associateApdb
+      target: associateApdb:diaForcedSource.run
   memory_alertPackager:
     class: lsst.verify.tasks.commonMetrics.MemoryMetricTask
     config:
       connections.package: ap_association
       connections.metric: PackageAlertsMemory
-      connections.labelName: diaPipe
-      target: diaPipe:alertPackager.run
+      connections.labelName: associateApdb
+      target: associateApdb:alertPackager.run
   timing_apPipe:
     class: lsst.ap.pipe.metrics.PipelineTimingMetricTask
     config:
       connections.package: ap_pipe
       connections.metric: ApPipelineTime
       connections.labelStart: isr
-      connections.labelEnd: analyzeTrailedDiaSrcCore
+      connections.labelEnd: analyzeTrailedDiaSourceTable
       targetStart: isr.run
-      targetEnd: analyzeTrailedDiaSrcCore.run
+      targetEnd: analyzeTrailedDiaSourceTable.run

--- a/python/lsst/ap/verify/pipeline_driver.py
+++ b/python/lsst/ap/verify/pipeline_driver.py
@@ -169,7 +169,7 @@ def _getExecOrder():
     # Source association algorithm is not time-symmetric. Force execution of
     # association (through DiaPipelineTask) in order of ascending visit number.
     return lsst.ctrl.mpexec.execFixupDataId.ExecFixupDataId(
-        taskLabel="diaPipe", dimensions=["visit", ], reverse=False)
+        taskLabel="associateApdb", dimensions=["visit", ], reverse=False)
 
 
 def _getPipelineFile(workspace, parsed):
@@ -244,7 +244,7 @@ def _getConfigArgumentsGen3(workspace, parsed):
         # APDB config should have been stored in the workspace.
         "--config", "parameters:apdb_config=" + workspace.dbConfigLocation,
         # Put output alerts into the workspace.
-        "--config", "diaPipe:alertPackager.alertWriteLocation=" + workspace.alertLocation,
+        "--config", "associateApdb:alertPackager.alertWriteLocation=" + workspace.alertLocation,
     ]
 
 


### PR DESCRIPTION
Renaming the datasets without updating the task defaults wreaks havoc on `ap_verify`, where we have to redefine diaPipe (now associateApdb) in many places. We should create a common config for associateApdb to simplify these definitions!

****

- [ ] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [ ] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [ ] Is the Sphinx documentation up-to-date?
