### PR TITLE
DM-51758: Create ap_verify CI dataset for ComCam

### DIFF
--- a/pipelines/LSSTComCam/ApVerify.yaml
+++ b/pipelines/LSSTComCam/ApVerify.yaml
@@ -1,0 +1,24 @@
+# Verification pipeline specialized for the DC2 ImSim simulation.
+# This concatenates various lsst.verify metrics to an AP pipeline
+
+description: Fully instrumented AP pipeline specialized for LSSTCam-imSim
+imports:
+  - location: $AP_VERIFY_DIR/pipelines/_ingredients/ApVerify.yaml
+    # Include all metrics from standard pipeline. It's not practical to create
+    # a metrics subset because it would require constant micromanagement.
+    exclude:
+      - prompt
+      - afterburner
+  - location: $AP_PIPE_DIR/pipelines/LSSTComCam/ApPipe.yaml
+    include:
+      - prompt
+      - afterburner
+tasks:
+  # ApVerify override removed by excluding apPipe.
+  associateApdb:
+    class: lsst.ap.association.DiaPipelineTask
+    config:
+      doPackageAlerts: True
+      alertPackager.doWriteAlerts: True
+contracts:
+  # Contracts removed by excluding apPipe

--- a/pipelines/LSSTComCam/ApVerifyWithFakes.yaml
+++ b/pipelines/LSSTComCam/ApVerifyWithFakes.yaml
@@ -1,0 +1,23 @@
+# Verification pipeline specialized for the DC2 ImSim simulation.
+# This concatenates various lsst.verify metrics to an AP pipeline
+
+instrument: lsst.obs.lsst.LsstCamImSim
+description: Fully instrumented AP pipeline with fakes, specialized for LSSTCam-imSim
+imports:
+  - location: $AP_VERIFY_DIR/pipelines/_ingredients/ApVerifyWithFakes.yaml
+    # Include all metrics from standard pipeline. It's not practical to create
+    # a metrics subset because it would require constant micromanagement.
+    exclude:
+      - prompt
+      - afterburner
+  - location: $AP_PIPE_DIR/pipelines/LSSTComCam/ApPipeWithFakes.yaml
+    include:
+      - prompt
+      - afterburner
+tasks:
+  # ApVerify override removed by excluding apPipe.
+  associateApdb:
+    class: lsst.ap.association.DiaPipelineTask
+    config:
+      doPackageAlerts: True
+      alertPackager.doWriteAlerts: True


### PR DESCRIPTION
Add LSSTComCam pipelines for new CI datasets

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x] Is the Sphinx documentation up-to-date?
