### PR TITLE
Fix bug originated from DM-51758

### DIFF
--- a/pipelines/LSSTComCam/ApVerify.yaml
+++ b/pipelines/LSSTComCam/ApVerify.yaml
@@ -20,5 +20,3 @@ tasks:
     config:
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
-contracts:
-  # Contracts removed by excluding apPipe


### PR DESCRIPTION
Removed the `contracts` section in the LSSTComCam pipeline yaml, which was empty and causing the pipeline to fail

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x] Is the Sphinx documentation up-to-date?
