### PR TITLE
Fix typo on pipelines mixing LSSTComCam with LSSTCam-imSim

### DIFF
--- a/pipelines/LSSTComCam/ApVerify.yaml
+++ b/pipelines/LSSTComCam/ApVerify.yaml
@@ -1,7 +1,7 @@
 # Verification pipeline specialized for the DC2 ImSim simulation.
 # This concatenates various lsst.verify metrics to an AP pipeline
 
-description: Fully instrumented AP pipeline specialized for LSSTCam-imSim
+description: Fully instrumented AP pipeline specialized for LSSTComCam
 imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ApVerify.yaml
     # Include all metrics from standard pipeline. It's not practical to create
@@ -20,3 +20,4 @@ tasks:
     config:
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
+      doSolarSystemAssociation: True

--- a/pipelines/LSSTComCam/ApVerifyWithFakes.yaml
+++ b/pipelines/LSSTComCam/ApVerifyWithFakes.yaml
@@ -1,8 +1,8 @@
 # Verification pipeline specialized for the DC2 ImSim simulation.
 # This concatenates various lsst.verify metrics to an AP pipeline
 
-instrument: lsst.obs.lsst.LsstCamImSim
-description: Fully instrumented AP pipeline with fakes, specialized for LSSTCam-imSim
+instrument: lsst.obs.lsst.LsstComCam
+description: Fully instrumented AP pipeline with fakes, specialized for LSSTComCam
 imports:
   - location: $AP_VERIFY_DIR/pipelines/_ingredients/ApVerifyWithFakes.yaml
     # Include all metrics from standard pipeline. It's not practical to create
@@ -21,3 +21,4 @@ tasks:
     config:
       doPackageAlerts: True
       alertPackager.doWriteAlerts: True
+      doSolarSystemAssociation: True


### PR DESCRIPTION
{Summary of changes. Prefix PR title with JIRA issue.}

****

- [x] Do unit tests pass (`scons` and/or `stack-os-matrix`)?
- [x] Did you run `ap_verify.py` on at least one of [the standard datasets](https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/datasets.html#supported-datasets)?
      For changes to metrics, the `print_metricvalues` script from `lsst.verify` will be useful.
- [x] Is the Sphinx documentation up-to-date?
